### PR TITLE
improved shariff.min.css

### DIFF
--- a/shariff.min.css
+++ b/shariff.min.css
@@ -7,4 +7,4395 @@
 /*!
  * Font Awesome Free 5.0.5 by @fontawesome - http://fontawesome.com
  * License - http://fontawesome.com/license (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License)
- */.fa,.fab,.fal,.far,.fas{-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased;display:inline-block;font-style:normal;font-variant:normal;text-rendering:auto;line-height:1}.fa-lg{font-size:1.33333333em;line-height:.75em;vertical-align:-.0667em}.fa-xs{font-size:.75em}.fa-sm{font-size:.875em}.fa-1x{font-size:1em}.fa-2x{font-size:2em}.fa-3x{font-size:3em}.fa-4x{font-size:4em}.fa-5x{font-size:5em}.fa-6x{font-size:6em}.fa-7x{font-size:7em}.fa-8x{font-size:8em}.fa-9x{font-size:9em}.fa-10x{font-size:10em}.fa-fw{text-align:center;width:1.25em}.fa-ul{list-style-type:none;margin-left:2em * 5/4;padding-left:0}.fa-ul>li{position:relative}.fa-li{left:-2em;position:absolute;text-align:center;width:2em;line-height:inherit}.fa-border{border-radius:.1em;border:.08em solid #eee;padding:.2em .25em .15em}.fa-pull-left{float:left}.fa-pull-right{float:right}.fa.fa-pull-left,.fab.fa-pull-left,.fal.fa-pull-left,.far.fa-pull-left,.fas.fa-pull-left{margin-right:.3em}.fa.fa-pull-right,.fab.fa-pull-right,.fal.fa-pull-right,.far.fa-pull-right,.fas.fa-pull-right{margin-left:.3em}.fa-spin{-webkit-animation:fa-spin 2s infinite linear;animation:fa-spin 2s infinite linear}.fa-pulse{-webkit-animation:fa-spin 1s infinite steps(8);animation:fa-spin 1s infinite steps(8)}@-webkit-keyframes fa-spin{0%{-webkit-transform:rotate(0deg);transform:rotate(0deg)}to{-webkit-transform:rotate(1turn);transform:rotate(1turn)}}@keyframes fa-spin{0%{-webkit-transform:rotate(0deg);transform:rotate(0deg)}to{-webkit-transform:rotate(1turn);transform:rotate(1turn)}}.fa-rotate-90{-ms-filter:"progid:DXImageTransform.Microsoft.BasicImage(rotation=1)";-webkit-transform:rotate(90deg);transform:rotate(90deg)}.fa-rotate-180{-ms-filter:"progid:DXImageTransform.Microsoft.BasicImage(rotation=2)";-webkit-transform:rotate(180deg);transform:rotate(180deg)}.fa-rotate-270{-ms-filter:"progid:DXImageTransform.Microsoft.BasicImage(rotation=3)";-webkit-transform:rotate(270deg);transform:rotate(270deg)}.fa-flip-horizontal{-ms-filter:"progid:DXImageTransform.Microsoft.BasicImage(rotation=0, mirror=1)";-webkit-transform:scaleX(-1);transform:scaleX(-1)}.fa-flip-vertical{-webkit-transform:scaleY(-1);transform:scaleY(-1)}.fa-flip-horizontal.fa-flip-vertical,.fa-flip-vertical{-ms-filter:"progid:DXImageTransform.Microsoft.BasicImage(rotation=2, mirror=1)"}.fa-flip-horizontal.fa-flip-vertical{-webkit-transform:scale(-1);transform:scale(-1)}:root .fa-flip-horizontal,:root .fa-flip-vertical,:root .fa-rotate-90,:root .fa-rotate-180,:root .fa-rotate-270{-webkit-filter:none;filter:none}.fa-stack{display:inline-block;height:2em;line-height:2em;position:relative;vertical-align:middle;width:2em}.fa-stack-1x,.fa-stack-2x{left:0;position:absolute;text-align:center;width:100%}.fa-stack-1x{line-height:inherit}.fa-stack-2x{font-size:2em}.fa-inverse{color:#fff}.fa-500px:before{content:"\F26E"}.fa-accessible-icon:before{content:"\F368"}.fa-accusoft:before{content:"\F369"}.fa-address-book:before{content:"\F2B9"}.fa-address-card:before{content:"\F2BB"}.fa-adjust:before{content:"\F042"}.fa-adn:before{content:"\F170"}.fa-adversal:before{content:"\F36A"}.fa-affiliatetheme:before{content:"\F36B"}.fa-algolia:before{content:"\F36C"}.fa-align-center:before{content:"\F037"}.fa-align-justify:before{content:"\F039"}.fa-align-left:before{content:"\F036"}.fa-align-right:before{content:"\F038"}.fa-amazon:before{content:"\F270"}.fa-amazon-pay:before{content:"\F42C"}.fa-ambulance:before{content:"\F0F9"}.fa-american-sign-language-interpreting:before{content:"\F2A3"}.fa-amilia:before{content:"\F36D"}.fa-anchor:before{content:"\F13D"}.fa-android:before{content:"\F17B"}.fa-angellist:before{content:"\F209"}.fa-angle-double-down:before{content:"\F103"}.fa-angle-double-left:before{content:"\F100"}.fa-angle-double-right:before{content:"\F101"}.fa-angle-double-up:before{content:"\F102"}.fa-angle-down:before{content:"\F107"}.fa-angle-left:before{content:"\F104"}.fa-angle-right:before{content:"\F105"}.fa-angle-up:before{content:"\F106"}.fa-angrycreative:before{content:"\F36E"}.fa-angular:before{content:"\F420"}.fa-app-store:before{content:"\F36F"}.fa-app-store-ios:before{content:"\F370"}.fa-apper:before{content:"\F371"}.fa-apple:before{content:"\F179"}.fa-apple-pay:before{content:"\F415"}.fa-archive:before{content:"\F187"}.fa-arrow-alt-circle-down:before{content:"\F358"}.fa-arrow-alt-circle-left:before{content:"\F359"}.fa-arrow-alt-circle-right:before{content:"\F35A"}.fa-arrow-alt-circle-up:before{content:"\F35B"}.fa-arrow-circle-down:before{content:"\F0AB"}.fa-arrow-circle-left:before{content:"\F0A8"}.fa-arrow-circle-right:before{content:"\F0A9"}.fa-arrow-circle-up:before{content:"\F0AA"}.fa-arrow-down:before{content:"\F063"}.fa-arrow-left:before{content:"\F060"}.fa-arrow-right:before{content:"\F061"}.fa-arrow-up:before{content:"\F062"}.fa-arrows-alt:before{content:"\F0B2"}.fa-arrows-alt-h:before{content:"\F337"}.fa-arrows-alt-v:before{content:"\F338"}.fa-assistive-listening-systems:before{content:"\F2A2"}.fa-asterisk:before{content:"\F069"}.fa-asymmetrik:before{content:"\F372"}.fa-at:before{content:"\F1FA"}.fa-audible:before{content:"\F373"}.fa-audio-description:before{content:"\F29E"}.fa-autoprefixer:before{content:"\F41C"}.fa-avianex:before{content:"\F374"}.fa-aviato:before{content:"\F421"}.fa-aws:before{content:"\F375"}.fa-backward:before{content:"\F04A"}.fa-balance-scale:before{content:"\F24E"}.fa-ban:before{content:"\F05E"}.fa-bandcamp:before{content:"\F2D5"}.fa-barcode:before{content:"\F02A"}.fa-bars:before{content:"\F0C9"}.fa-baseball-ball:before{content:"\F433"}.fa-basketball-ball:before{content:"\F434"}.fa-bath:before{content:"\F2CD"}.fa-battery-empty:before{content:"\F244"}.fa-battery-full:before{content:"\F240"}.fa-battery-half:before{content:"\F242"}.fa-battery-quarter:before{content:"\F243"}.fa-battery-three-quarters:before{content:"\F241"}.fa-bed:before{content:"\F236"}.fa-beer:before{content:"\F0FC"}.fa-behance:before{content:"\F1B4"}.fa-behance-square:before{content:"\F1B5"}.fa-bell:before{content:"\F0F3"}.fa-bell-slash:before{content:"\F1F6"}.fa-bicycle:before{content:"\F206"}.fa-bimobject:before{content:"\F378"}.fa-binoculars:before{content:"\F1E5"}.fa-birthday-cake:before{content:"\F1FD"}.fa-bitbucket:before{content:"\F171"}.fa-bitcoin:before{content:"\F379"}.fa-bity:before{content:"\F37A"}.fa-black-tie:before{content:"\F27E"}.fa-blackberry:before{content:"\F37B"}.fa-blind:before{content:"\F29D"}.fa-blogger:before{content:"\F37C"}.fa-blogger-b:before{content:"\F37D"}.fa-bluetooth:before{content:"\F293"}.fa-bluetooth-b:before{content:"\F294"}.fa-bold:before{content:"\F032"}.fa-bolt:before{content:"\F0E7"}.fa-bomb:before{content:"\F1E2"}.fa-book:before{content:"\F02D"}.fa-bookmark:before{content:"\F02E"}.fa-bowling-ball:before{content:"\F436"}.fa-braille:before{content:"\F2A1"}.fa-briefcase:before{content:"\F0B1"}.fa-btc:before{content:"\F15A"}.fa-bug:before{content:"\F188"}.fa-building:before{content:"\F1AD"}.fa-bullhorn:before{content:"\F0A1"}.fa-bullseye:before{content:"\F140"}.fa-buromobelexperte:before{content:"\F37F"}.fa-bus:before{content:"\F207"}.fa-buysellads:before{content:"\F20D"}.fa-calculator:before{content:"\F1EC"}.fa-calendar:before{content:"\F133"}.fa-calendar-alt:before{content:"\F073"}.fa-calendar-check:before{content:"\F274"}.fa-calendar-minus:before{content:"\F272"}.fa-calendar-plus:before{content:"\F271"}.fa-calendar-times:before{content:"\F273"}.fa-camera:before{content:"\F030"}.fa-camera-retro:before{content:"\F083"}.fa-car:before{content:"\F1B9"}.fa-caret-down:before{content:"\F0D7"}.fa-caret-left:before{content:"\F0D9"}.fa-caret-right:before{content:"\F0DA"}.fa-caret-square-down:before{content:"\F150"}.fa-caret-square-left:before{content:"\F191"}.fa-caret-square-right:before{content:"\F152"}.fa-caret-square-up:before{content:"\F151"}.fa-caret-up:before{content:"\F0D8"}.fa-cart-arrow-down:before{content:"\F218"}.fa-cart-plus:before{content:"\F217"}.fa-cc-amazon-pay:before{content:"\F42D"}.fa-cc-amex:before{content:"\F1F3"}.fa-cc-apple-pay:before{content:"\F416"}.fa-cc-diners-club:before{content:"\F24C"}.fa-cc-discover:before{content:"\F1F2"}.fa-cc-jcb:before{content:"\F24B"}.fa-cc-mastercard:before{content:"\F1F1"}.fa-cc-paypal:before{content:"\F1F4"}.fa-cc-stripe:before{content:"\F1F5"}.fa-cc-visa:before{content:"\F1F0"}.fa-centercode:before{content:"\F380"}.fa-certificate:before{content:"\F0A3"}.fa-chart-area:before{content:"\F1FE"}.fa-chart-bar:before{content:"\F080"}.fa-chart-line:before{content:"\F201"}.fa-chart-pie:before{content:"\F200"}.fa-check:before{content:"\F00C"}.fa-check-circle:before{content:"\F058"}.fa-check-square:before{content:"\F14A"}.fa-chess:before{content:"\F439"}.fa-chess-bishop:before{content:"\F43A"}.fa-chess-board:before{content:"\F43C"}.fa-chess-king:before{content:"\F43F"}.fa-chess-knight:before{content:"\F441"}.fa-chess-pawn:before{content:"\F443"}.fa-chess-queen:before{content:"\F445"}.fa-chess-rook:before{content:"\F447"}.fa-chevron-circle-down:before{content:"\F13A"}.fa-chevron-circle-left:before{content:"\F137"}.fa-chevron-circle-right:before{content:"\F138"}.fa-chevron-circle-up:before{content:"\F139"}.fa-chevron-down:before{content:"\F078"}.fa-chevron-left:before{content:"\F053"}.fa-chevron-right:before{content:"\F054"}.fa-chevron-up:before{content:"\F077"}.fa-child:before{content:"\F1AE"}.fa-chrome:before{content:"\F268"}.fa-circle:before{content:"\F111"}.fa-circle-notch:before{content:"\F1CE"}.fa-clipboard:before{content:"\F328"}.fa-clock:before{content:"\F017"}.fa-clone:before{content:"\F24D"}.fa-closed-captioning:before{content:"\F20A"}.fa-cloud:before{content:"\F0C2"}.fa-cloud-download-alt:before{content:"\F381"}.fa-cloud-upload-alt:before{content:"\F382"}.fa-cloudscale:before{content:"\F383"}.fa-cloudsmith:before{content:"\F384"}.fa-cloudversify:before{content:"\F385"}.fa-code:before{content:"\F121"}.fa-code-branch:before{content:"\F126"}.fa-codepen:before{content:"\F1CB"}.fa-codiepie:before{content:"\F284"}.fa-coffee:before{content:"\F0F4"}.fa-cog:before{content:"\F013"}.fa-cogs:before{content:"\F085"}.fa-columns:before{content:"\F0DB"}.fa-comment:before{content:"\F075"}.fa-comment-alt:before{content:"\F27A"}.fa-comments:before{content:"\F086"}.fa-compass:before{content:"\F14E"}.fa-compress:before{content:"\F066"}.fa-connectdevelop:before{content:"\F20E"}.fa-contao:before{content:"\F26D"}.fa-copy:before{content:"\F0C5"}.fa-copyright:before{content:"\F1F9"}.fa-cpanel:before{content:"\F388"}.fa-creative-commons:before{content:"\F25E"}.fa-credit-card:before{content:"\F09D"}.fa-crop:before{content:"\F125"}.fa-crosshairs:before{content:"\F05B"}.fa-css3:before{content:"\F13C"}.fa-css3-alt:before{content:"\F38B"}.fa-cube:before{content:"\F1B2"}.fa-cubes:before{content:"\F1B3"}.fa-cut:before{content:"\F0C4"}.fa-cuttlefish:before{content:"\F38C"}.fa-d-and-d:before{content:"\F38D"}.fa-dashcube:before{content:"\F210"}.fa-database:before{content:"\F1C0"}.fa-deaf:before{content:"\F2A4"}.fa-delicious:before{content:"\F1A5"}.fa-deploydog:before{content:"\F38E"}.fa-deskpro:before{content:"\F38F"}.fa-desktop:before{content:"\F108"}.fa-deviantart:before{content:"\F1BD"}.fa-digg:before{content:"\F1A6"}.fa-digital-ocean:before{content:"\F391"}.fa-discord:before{content:"\F392"}.fa-discourse:before{content:"\F393"}.fa-dochub:before{content:"\F394"}.fa-docker:before{content:"\F395"}.fa-dollar-sign:before{content:"\F155"}.fa-dot-circle:before{content:"\F192"}.fa-download:before{content:"\F019"}.fa-draft2digital:before{content:"\F396"}.fa-dribbble:before{content:"\F17D"}.fa-dribbble-square:before{content:"\F397"}.fa-dropbox:before{content:"\F16B"}.fa-drupal:before{content:"\F1A9"}.fa-dyalog:before{content:"\F399"}.fa-earlybirds:before{content:"\F39A"}.fa-edge:before{content:"\F282"}.fa-edit:before{content:"\F044"}.fa-eject:before{content:"\F052"}.fa-elementor:before{content:"\F430"}.fa-ellipsis-h:before{content:"\F141"}.fa-ellipsis-v:before{content:"\F142"}.fa-ember:before{content:"\F423"}.fa-empire:before{content:"\F1D1"}.fa-envelope:before{content:"\F0E0"}.fa-envelope-open:before{content:"\F2B6"}.fa-envelope-square:before{content:"\F199"}.fa-envira:before{content:"\F299"}.fa-eraser:before{content:"\F12D"}.fa-erlang:before{content:"\F39D"}.fa-ethereum:before{content:"\F42E"}.fa-etsy:before{content:"\F2D7"}.fa-euro-sign:before{content:"\F153"}.fa-exchange-alt:before{content:"\F362"}.fa-exclamation:before{content:"\F12A"}.fa-exclamation-circle:before{content:"\F06A"}.fa-exclamation-triangle:before{content:"\F071"}.fa-expand:before{content:"\F065"}.fa-expand-arrows-alt:before{content:"\F31E"}.fa-expeditedssl:before{content:"\F23E"}.fa-external-link-alt:before{content:"\F35D"}.fa-external-link-square-alt:before{content:"\F360"}.fa-eye:before{content:"\F06E"}.fa-eye-dropper:before{content:"\F1FB"}.fa-eye-slash:before{content:"\F070"}.fa-facebook:before{content:"\F09A"}.fa-facebook-f:before{content:"\F39E"}.fa-facebook-messenger:before{content:"\F39F"}.fa-facebook-square:before{content:"\F082"}.fa-fast-backward:before{content:"\F049"}.fa-fast-forward:before{content:"\F050"}.fa-fax:before{content:"\F1AC"}.fa-female:before{content:"\F182"}.fa-fighter-jet:before{content:"\F0FB"}.fa-file:before{content:"\F15B"}.fa-file-alt:before{content:"\F15C"}.fa-file-archive:before{content:"\F1C6"}.fa-file-audio:before{content:"\F1C7"}.fa-file-code:before{content:"\F1C9"}.fa-file-excel:before{content:"\F1C3"}.fa-file-image:before{content:"\F1C5"}.fa-file-pdf:before{content:"\F1C1"}.fa-file-powerpoint:before{content:"\F1C4"}.fa-file-video:before{content:"\F1C8"}.fa-file-word:before{content:"\F1C2"}.fa-film:before{content:"\F008"}.fa-filter:before{content:"\F0B0"}.fa-fire:before{content:"\F06D"}.fa-fire-extinguisher:before{content:"\F134"}.fa-firefox:before{content:"\F269"}.fa-first-order:before{content:"\F2B0"}.fa-firstdraft:before{content:"\F3A1"}.fa-flag:before{content:"\F024"}.fa-flag-checkered:before{content:"\F11E"}.fa-flask:before{content:"\F0C3"}.fa-flickr:before{content:"\F16E"}.fa-flipboard:before{content:"\F44D"}.fa-fly:before{content:"\F417"}.fa-folder:before{content:"\F07B"}.fa-folder-open:before{content:"\F07C"}.fa-font:before{content:"\F031"}.fa-font-awesome:before{content:"\F2B4"}.fa-font-awesome-alt:before{content:"\F35C"}.fa-font-awesome-flag:before{content:"\F425"}.fa-fonticons:before{content:"\F280"}.fa-fonticons-fi:before{content:"\F3A2"}.fa-football-ball:before{content:"\F44E"}.fa-fort-awesome:before{content:"\F286"}.fa-fort-awesome-alt:before{content:"\F3A3"}.fa-forumbee:before{content:"\F211"}.fa-forward:before{content:"\F04E"}.fa-foursquare:before{content:"\F180"}.fa-free-code-camp:before{content:"\F2C5"}.fa-freebsd:before{content:"\F3A4"}.fa-frown:before{content:"\F119"}.fa-futbol:before{content:"\F1E3"}.fa-gamepad:before{content:"\F11B"}.fa-gavel:before{content:"\F0E3"}.fa-gem:before{content:"\F3A5"}.fa-genderless:before{content:"\F22D"}.fa-get-pocket:before{content:"\F265"}.fa-gg:before{content:"\F260"}.fa-gg-circle:before{content:"\F261"}.fa-gift:before{content:"\F06B"}.fa-git:before{content:"\F1D3"}.fa-git-square:before{content:"\F1D2"}.fa-github:before{content:"\F09B"}.fa-github-alt:before{content:"\F113"}.fa-github-square:before{content:"\F092"}.fa-gitkraken:before{content:"\F3A6"}.fa-gitlab:before{content:"\F296"}.fa-gitter:before{content:"\F426"}.fa-glass-martini:before{content:"\F000"}.fa-glide:before{content:"\F2A5"}.fa-glide-g:before{content:"\F2A6"}.fa-globe:before{content:"\F0AC"}.fa-gofore:before{content:"\F3A7"}.fa-golf-ball:before{content:"\F450"}.fa-goodreads:before{content:"\F3A8"}.fa-goodreads-g:before{content:"\F3A9"}.fa-google:before{content:"\F1A0"}.fa-google-drive:before{content:"\F3AA"}.fa-google-play:before{content:"\F3AB"}.fa-google-plus:before{content:"\F2B3"}.fa-google-plus-g:before{content:"\F0D5"}.fa-google-plus-square:before{content:"\F0D4"}.fa-google-wallet:before{content:"\F1EE"}.fa-graduation-cap:before{content:"\F19D"}.fa-gratipay:before{content:"\F184"}.fa-grav:before{content:"\F2D6"}.fa-gripfire:before{content:"\F3AC"}.fa-grunt:before{content:"\F3AD"}.fa-gulp:before{content:"\F3AE"}.fa-h-square:before{content:"\F0FD"}.fa-hacker-news:before{content:"\F1D4"}.fa-hacker-news-square:before{content:"\F3AF"}.fa-hand-lizard:before{content:"\F258"}.fa-hand-paper:before{content:"\F256"}.fa-hand-peace:before{content:"\F25B"}.fa-hand-point-down:before{content:"\F0A7"}.fa-hand-point-left:before{content:"\F0A5"}.fa-hand-point-right:before{content:"\F0A4"}.fa-hand-point-up:before{content:"\F0A6"}.fa-hand-pointer:before{content:"\F25A"}.fa-hand-rock:before{content:"\F255"}.fa-hand-scissors:before{content:"\F257"}.fa-hand-spock:before{content:"\F259"}.fa-handshake:before{content:"\F2B5"}.fa-hashtag:before{content:"\F292"}.fa-hdd:before{content:"\F0A0"}.fa-heading:before{content:"\F1DC"}.fa-headphones:before{content:"\F025"}.fa-heart:before{content:"\F004"}.fa-heartbeat:before{content:"\F21E"}.fa-hips:before{content:"\F452"}.fa-hire-a-helper:before{content:"\F3B0"}.fa-history:before{content:"\F1DA"}.fa-hockey-puck:before{content:"\F453"}.fa-home:before{content:"\F015"}.fa-hooli:before{content:"\F427"}.fa-hospital:before{content:"\F0F8"}.fa-hotjar:before{content:"\F3B1"}.fa-hourglass:before{content:"\F254"}.fa-hourglass-end:before{content:"\F253"}.fa-hourglass-half:before{content:"\F252"}.fa-hourglass-start:before{content:"\F251"}.fa-houzz:before{content:"\F27C"}.fa-html5:before{content:"\F13B"}.fa-hubspot:before{content:"\F3B2"}.fa-i-cursor:before{content:"\F246"}.fa-id-badge:before{content:"\F2C1"}.fa-id-card:before{content:"\F2C2"}.fa-image:before{content:"\F03E"}.fa-images:before{content:"\F302"}.fa-imdb:before{content:"\F2D8"}.fa-inbox:before{content:"\F01C"}.fa-indent:before{content:"\F03C"}.fa-industry:before{content:"\F275"}.fa-info:before{content:"\F129"}.fa-info-circle:before{content:"\F05A"}.fa-instagram:before{content:"\F16D"}.fa-internet-explorer:before{content:"\F26B"}.fa-ioxhost:before{content:"\F208"}.fa-italic:before{content:"\F033"}.fa-itunes:before{content:"\F3B4"}.fa-itunes-note:before{content:"\F3B5"}.fa-jenkins:before{content:"\F3B6"}.fa-joget:before{content:"\F3B7"}.fa-joomla:before{content:"\F1AA"}.fa-js:before{content:"\F3B8"}.fa-js-square:before{content:"\F3B9"}.fa-jsfiddle:before{content:"\F1CC"}.fa-key:before{content:"\F084"}.fa-keyboard:before{content:"\F11C"}.fa-keycdn:before{content:"\F3BA"}.fa-kickstarter:before{content:"\F3BB"}.fa-kickstarter-k:before{content:"\F3BC"}.fa-korvue:before{content:"\F42F"}.fa-language:before{content:"\F1AB"}.fa-laptop:before{content:"\F109"}.fa-laravel:before{content:"\F3BD"}.fa-lastfm:before{content:"\F202"}.fa-lastfm-square:before{content:"\F203"}.fa-leaf:before{content:"\F06C"}.fa-leanpub:before{content:"\F212"}.fa-lemon:before{content:"\F094"}.fa-less:before{content:"\F41D"}.fa-level-down-alt:before{content:"\F3BE"}.fa-level-up-alt:before{content:"\F3BF"}.fa-life-ring:before{content:"\F1CD"}.fa-lightbulb:before{content:"\F0EB"}.fa-line:before{content:"\F3C0"}.fa-link:before{content:"\F0C1"}.fa-linkedin:before{content:"\F08C"}.fa-linkedin-in:before{content:"\F0E1"}.fa-linode:before{content:"\F2B8"}.fa-linux:before{content:"\F17C"}.fa-lira-sign:before{content:"\F195"}.fa-list:before{content:"\F03A"}.fa-list-alt:before{content:"\F022"}.fa-list-ol:before{content:"\F0CB"}.fa-list-ul:before{content:"\F0CA"}.fa-location-arrow:before{content:"\F124"}.fa-lock:before{content:"\F023"}.fa-lock-open:before{content:"\F3C1"}.fa-long-arrow-alt-down:before{content:"\F309"}.fa-long-arrow-alt-left:before{content:"\F30A"}.fa-long-arrow-alt-right:before{content:"\F30B"}.fa-long-arrow-alt-up:before{content:"\F30C"}.fa-low-vision:before{content:"\F2A8"}.fa-lyft:before{content:"\F3C3"}.fa-magento:before{content:"\F3C4"}.fa-magic:before{content:"\F0D0"}.fa-magnet:before{content:"\F076"}.fa-male:before{content:"\F183"}.fa-map:before{content:"\F279"}.fa-map-marker:before{content:"\F041"}.fa-map-marker-alt:before{content:"\F3C5"}.fa-map-pin:before{content:"\F276"}.fa-map-signs:before{content:"\F277"}.fa-mars:before{content:"\F222"}.fa-mars-double:before{content:"\F227"}.fa-mars-stroke:before{content:"\F229"}.fa-mars-stroke-h:before{content:"\F22B"}.fa-mars-stroke-v:before{content:"\F22A"}.fa-maxcdn:before{content:"\F136"}.fa-medapps:before{content:"\F3C6"}.fa-medium:before{content:"\F23A"}.fa-medium-m:before{content:"\F3C7"}.fa-medkit:before{content:"\F0FA"}.fa-medrt:before{content:"\F3C8"}.fa-meetup:before{content:"\F2E0"}.fa-meh:before{content:"\F11A"}.fa-mercury:before{content:"\F223"}.fa-microchip:before{content:"\F2DB"}.fa-microphone:before{content:"\F130"}.fa-microphone-slash:before{content:"\F131"}.fa-microsoft:before{content:"\F3CA"}.fa-minus:before{content:"\F068"}.fa-minus-circle:before{content:"\F056"}.fa-minus-square:before{content:"\F146"}.fa-mix:before{content:"\F3CB"}.fa-mixcloud:before{content:"\F289"}.fa-mizuni:before{content:"\F3CC"}.fa-mobile:before{content:"\F10B"}.fa-mobile-alt:before{content:"\F3CD"}.fa-modx:before{content:"\F285"}.fa-monero:before{content:"\F3D0"}.fa-money-bill-alt:before{content:"\F3D1"}.fa-moon:before{content:"\F186"}.fa-motorcycle:before{content:"\F21C"}.fa-mouse-pointer:before{content:"\F245"}.fa-music:before{content:"\F001"}.fa-napster:before{content:"\F3D2"}.fa-neuter:before{content:"\F22C"}.fa-newspaper:before{content:"\F1EA"}.fa-nintendo-switch:before{content:"\F418"}.fa-node:before{content:"\F419"}.fa-node-js:before{content:"\F3D3"}.fa-npm:before{content:"\F3D4"}.fa-ns8:before{content:"\F3D5"}.fa-nutritionix:before{content:"\F3D6"}.fa-object-group:before{content:"\F247"}.fa-object-ungroup:before{content:"\F248"}.fa-odnoklassniki:before{content:"\F263"}.fa-odnoklassniki-square:before{content:"\F264"}.fa-opencart:before{content:"\F23D"}.fa-openid:before{content:"\F19B"}.fa-opera:before{content:"\F26A"}.fa-optin-monster:before{content:"\F23C"}.fa-osi:before{content:"\F41A"}.fa-outdent:before{content:"\F03B"}.fa-page4:before{content:"\F3D7"}.fa-pagelines:before{content:"\F18C"}.fa-paint-brush:before{content:"\F1FC"}.fa-palfed:before{content:"\F3D8"}.fa-paper-plane:before{content:"\F1D8"}.fa-paperclip:before{content:"\F0C6"}.fa-paragraph:before{content:"\F1DD"}.fa-paste:before{content:"\F0EA"}.fa-patreon:before{content:"\F3D9"}.fa-pause:before{content:"\F04C"}.fa-pause-circle:before{content:"\F28B"}.fa-paw:before{content:"\F1B0"}.fa-paypal:before{content:"\F1ED"}.fa-pen-square:before{content:"\F14B"}.fa-pencil-alt:before{content:"\F303"}.fa-percent:before{content:"\F295"}.fa-periscope:before{content:"\F3DA"}.fa-phabricator:before{content:"\F3DB"}.fa-phoenix-framework:before{content:"\F3DC"}.fa-phone:before{content:"\F095"}.fa-phone-square:before{content:"\F098"}.fa-phone-volume:before{content:"\F2A0"}.fa-php:before{content:"\F457"}.fa-pied-piper:before{content:"\F2AE"}.fa-pied-piper-alt:before{content:"\F1A8"}.fa-pied-piper-pp:before{content:"\F1A7"}.fa-pinterest:before{content:"\F0D2"}.fa-pinterest-p:before{content:"\F231"}.fa-pinterest-square:before{content:"\F0D3"}.fa-plane:before{content:"\F072"}.fa-play:before{content:"\F04B"}.fa-play-circle:before{content:"\F144"}.fa-playstation:before{content:"\F3DF"}.fa-plug:before{content:"\F1E6"}.fa-plus:before{content:"\F067"}.fa-plus-circle:before{content:"\F055"}.fa-plus-square:before{content:"\F0FE"}.fa-podcast:before{content:"\F2CE"}.fa-pound-sign:before{content:"\F154"}.fa-power-off:before{content:"\F011"}.fa-print:before{content:"\F02F"}.fa-product-hunt:before{content:"\F288"}.fa-pushed:before{content:"\F3E1"}.fa-puzzle-piece:before{content:"\F12E"}.fa-python:before{content:"\F3E2"}.fa-qq:before{content:"\F1D6"}.fa-qrcode:before{content:"\F029"}.fa-question:before{content:"\F128"}.fa-question-circle:before{content:"\F059"}.fa-quidditch:before{content:"\F458"}.fa-quinscape:before{content:"\F459"}.fa-quora:before{content:"\F2C4"}.fa-quote-left:before{content:"\F10D"}.fa-quote-right:before{content:"\F10E"}.fa-random:before{content:"\F074"}.fa-ravelry:before{content:"\F2D9"}.fa-react:before{content:"\F41B"}.fa-rebel:before{content:"\F1D0"}.fa-recycle:before{content:"\F1B8"}.fa-red-river:before{content:"\F3E3"}.fa-reddit:before{content:"\F1A1"}.fa-reddit-alien:before{content:"\F281"}.fa-reddit-square:before{content:"\F1A2"}.fa-redo:before{content:"\F01E"}.fa-redo-alt:before{content:"\F2F9"}.fa-registered:before{content:"\F25D"}.fa-rendact:before{content:"\F3E4"}.fa-renren:before{content:"\F18B"}.fa-reply:before{content:"\F3E5"}.fa-reply-all:before{content:"\F122"}.fa-replyd:before{content:"\F3E6"}.fa-resolving:before{content:"\F3E7"}.fa-retweet:before{content:"\F079"}.fa-road:before{content:"\F018"}.fa-rocket:before{content:"\F135"}.fa-rocketchat:before{content:"\F3E8"}.fa-rockrms:before{content:"\F3E9"}.fa-rss:before{content:"\F09E"}.fa-rss-square:before{content:"\F143"}.fa-ruble-sign:before{content:"\F158"}.fa-rupee-sign:before{content:"\F156"}.fa-safari:before{content:"\F267"}.fa-sass:before{content:"\F41E"}.fa-save:before{content:"\F0C7"}.fa-schlix:before{content:"\F3EA"}.fa-scribd:before{content:"\F28A"}.fa-search:before{content:"\F002"}.fa-search-minus:before{content:"\F010"}.fa-search-plus:before{content:"\F00E"}.fa-searchengin:before{content:"\F3EB"}.fa-sellcast:before{content:"\F2DA"}.fa-sellsy:before{content:"\F213"}.fa-server:before{content:"\F233"}.fa-servicestack:before{content:"\F3EC"}.fa-share:before{content:"\F064"}.fa-share-alt:before{content:"\F1E0"}.fa-share-alt-square:before{content:"\F1E1"}.fa-share-square:before{content:"\F14D"}.fa-shekel-sign:before{content:"\F20B"}.fa-shield-alt:before{content:"\F3ED"}.fa-ship:before{content:"\F21A"}.fa-shirtsinbulk:before{content:"\F214"}.fa-shopping-bag:before{content:"\F290"}.fa-shopping-basket:before{content:"\F291"}.fa-shopping-cart:before{content:"\F07A"}.fa-shower:before{content:"\F2CC"}.fa-sign-in-alt:before{content:"\F2F6"}.fa-sign-language:before{content:"\F2A7"}.fa-sign-out-alt:before{content:"\F2F5"}.fa-signal:before{content:"\F012"}.fa-simplybuilt:before{content:"\F215"}.fa-sistrix:before{content:"\F3EE"}.fa-sitemap:before{content:"\F0E8"}.fa-skyatlas:before{content:"\F216"}.fa-skype:before{content:"\F17E"}.fa-slack:before{content:"\F198"}.fa-slack-hash:before{content:"\F3EF"}.fa-sliders-h:before{content:"\F1DE"}.fa-slideshare:before{content:"\F1E7"}.fa-smile:before{content:"\F118"}.fa-snapchat:before{content:"\F2AB"}.fa-snapchat-ghost:before{content:"\F2AC"}.fa-snapchat-square:before{content:"\F2AD"}.fa-snowflake:before{content:"\F2DC"}.fa-sort:before{content:"\F0DC"}.fa-sort-alpha-down:before{content:"\F15D"}.fa-sort-alpha-up:before{content:"\F15E"}.fa-sort-amount-down:before{content:"\F160"}.fa-sort-amount-up:before{content:"\F161"}.fa-sort-down:before{content:"\F0DD"}.fa-sort-numeric-down:before{content:"\F162"}.fa-sort-numeric-up:before{content:"\F163"}.fa-sort-up:before{content:"\F0DE"}.fa-soundcloud:before{content:"\F1BE"}.fa-space-shuttle:before{content:"\F197"}.fa-speakap:before{content:"\F3F3"}.fa-spinner:before{content:"\F110"}.fa-spotify:before{content:"\F1BC"}.fa-square:before{content:"\F0C8"}.fa-square-full:before{content:"\F45C"}.fa-stack-exchange:before{content:"\F18D"}.fa-stack-overflow:before{content:"\F16C"}.fa-star:before{content:"\F005"}.fa-star-half:before{content:"\F089"}.fa-staylinked:before{content:"\F3F5"}.fa-steam:before{content:"\F1B6"}.fa-steam-square:before{content:"\F1B7"}.fa-steam-symbol:before{content:"\F3F6"}.fa-step-backward:before{content:"\F048"}.fa-step-forward:before{content:"\F051"}.fa-stethoscope:before{content:"\F0F1"}.fa-sticker-mule:before{content:"\F3F7"}.fa-sticky-note:before{content:"\F249"}.fa-stop:before{content:"\F04D"}.fa-stop-circle:before{content:"\F28D"}.fa-stopwatch:before{content:"\F2F2"}.fa-strava:before{content:"\F428"}.fa-street-view:before{content:"\F21D"}.fa-strikethrough:before{content:"\F0CC"}.fa-stripe:before{content:"\F429"}.fa-stripe-s:before{content:"\F42A"}.fa-studiovinari:before{content:"\F3F8"}.fa-stumbleupon:before{content:"\F1A4"}.fa-stumbleupon-circle:before{content:"\F1A3"}.fa-subscript:before{content:"\F12C"}.fa-subway:before{content:"\F239"}.fa-suitcase:before{content:"\F0F2"}.fa-sun:before{content:"\F185"}.fa-superpowers:before{content:"\F2DD"}.fa-superscript:before{content:"\F12B"}.fa-supple:before{content:"\F3F9"}.fa-sync:before{content:"\F021"}.fa-sync-alt:before{content:"\F2F1"}.fa-table:before{content:"\F0CE"}.fa-table-tennis:before{content:"\F45D"}.fa-tablet:before{content:"\F10A"}.fa-tablet-alt:before{content:"\F3FA"}.fa-tachometer-alt:before{content:"\F3FD"}.fa-tag:before{content:"\F02B"}.fa-tags:before{content:"\F02C"}.fa-tasks:before{content:"\F0AE"}.fa-taxi:before{content:"\F1BA"}.fa-telegram:before{content:"\F2C6"}.fa-telegram-plane:before{content:"\F3FE"}.fa-tencent-weibo:before{content:"\F1D5"}.fa-terminal:before{content:"\F120"}.fa-text-height:before{content:"\F034"}.fa-text-width:before{content:"\F035"}.fa-th:before{content:"\F00A"}.fa-th-large:before{content:"\F009"}.fa-th-list:before{content:"\F00B"}.fa-themeisle:before{content:"\F2B2"}.fa-thermometer-empty:before{content:"\F2CB"}.fa-thermometer-full:before{content:"\F2C7"}.fa-thermometer-half:before{content:"\F2C9"}.fa-thermometer-quarter:before{content:"\F2CA"}.fa-thermometer-three-quarters:before{content:"\F2C8"}.fa-thumbs-down:before{content:"\F165"}.fa-thumbs-up:before{content:"\F164"}.fa-thumbtack:before{content:"\F08D"}.fa-ticket-alt:before{content:"\F3FF"}.fa-times:before{content:"\F00D"}.fa-times-circle:before{content:"\F057"}.fa-tint:before{content:"\F043"}.fa-toggle-off:before{content:"\F204"}.fa-toggle-on:before{content:"\F205"}.fa-trademark:before{content:"\F25C"}.fa-train:before{content:"\F238"}.fa-transgender:before{content:"\F224"}.fa-transgender-alt:before{content:"\F225"}.fa-trash:before{content:"\F1F8"}.fa-trash-alt:before{content:"\F2ED"}.fa-tree:before{content:"\F1BB"}.fa-trello:before{content:"\F181"}.fa-tripadvisor:before{content:"\F262"}.fa-trophy:before{content:"\F091"}.fa-truck:before{content:"\F0D1"}.fa-tty:before{content:"\F1E4"}.fa-tumblr:before{content:"\F173"}.fa-tumblr-square:before{content:"\F174"}.fa-tv:before{content:"\F26C"}.fa-twitch:before{content:"\F1E8"}.fa-twitter:before{content:"\F099"}.fa-twitter-square:before{content:"\F081"}.fa-typo3:before{content:"\F42B"}.fa-uber:before{content:"\F402"}.fa-uikit:before{content:"\F403"}.fa-umbrella:before{content:"\F0E9"}.fa-underline:before{content:"\F0CD"}.fa-undo:before{content:"\F0E2"}.fa-undo-alt:before{content:"\F2EA"}.fa-uniregistry:before{content:"\F404"}.fa-universal-access:before{content:"\F29A"}.fa-university:before{content:"\F19C"}.fa-unlink:before{content:"\F127"}.fa-unlock:before{content:"\F09C"}.fa-unlock-alt:before{content:"\F13E"}.fa-untappd:before{content:"\F405"}.fa-upload:before{content:"\F093"}.fa-usb:before{content:"\F287"}.fa-user:before{content:"\F007"}.fa-user-circle:before{content:"\F2BD"}.fa-user-md:before{content:"\F0F0"}.fa-user-plus:before{content:"\F234"}.fa-user-secret:before{content:"\F21B"}.fa-user-times:before{content:"\F235"}.fa-users:before{content:"\F0C0"}.fa-ussunnah:before{content:"\F407"}.fa-utensil-spoon:before{content:"\F2E5"}.fa-utensils:before{content:"\F2E7"}.fa-vaadin:before{content:"\F408"}.fa-venus:before{content:"\F221"}.fa-venus-double:before{content:"\F226"}.fa-venus-mars:before{content:"\F228"}.fa-viacoin:before{content:"\F237"}.fa-viadeo:before{content:"\F2A9"}.fa-viadeo-square:before{content:"\F2AA"}.fa-viber:before{content:"\F409"}.fa-video:before{content:"\F03D"}.fa-vimeo:before{content:"\F40A"}.fa-vimeo-square:before{content:"\F194"}.fa-vimeo-v:before{content:"\F27D"}.fa-vine:before{content:"\F1CA"}.fa-vk:before{content:"\F189"}.fa-vnv:before{content:"\F40B"}.fa-volleyball-ball:before{content:"\F45F"}.fa-volume-down:before{content:"\F027"}.fa-volume-off:before{content:"\F026"}.fa-volume-up:before{content:"\F028"}.fa-vuejs:before{content:"\F41F"}.fa-weibo:before{content:"\F18A"}.fa-weixin:before{content:"\F1D7"}.fa-whatsapp:before{content:"\F232"}.fa-whatsapp-square:before{content:"\F40C"}.fa-wheelchair:before{content:"\F193"}.fa-whmcs:before{content:"\F40D"}.fa-wifi:before{content:"\F1EB"}.fa-wikipedia-w:before{content:"\F266"}.fa-window-close:before{content:"\F410"}.fa-window-maximize:before{content:"\F2D0"}.fa-window-minimize:before{content:"\F2D1"}.fa-window-restore:before{content:"\F2D2"}.fa-windows:before{content:"\F17A"}.fa-won-sign:before{content:"\F159"}.fa-wordpress:before{content:"\F19A"}.fa-wordpress-simple:before{content:"\F411"}.fa-wpbeginner:before{content:"\F297"}.fa-wpexplorer:before{content:"\F2DE"}.fa-wpforms:before{content:"\F298"}.fa-wrench:before{content:"\F0AD"}.fa-xbox:before{content:"\F412"}.fa-xing:before{content:"\F168"}.fa-xing-square:before{content:"\F169"}.fa-y-combinator:before{content:"\F23B"}.fa-yahoo:before{content:"\F19E"}.fa-yandex:before{content:"\F413"}.fa-yandex-international:before{content:"\F414"}.fa-yelp:before{content:"\F1E9"}.fa-yen-sign:before{content:"\F157"}.fa-yoast:before{content:"\F2B1"}.fa-youtube:before{content:"\F167"}.fa-youtube-square:before{content:"\F431"}.sr-only{border:0;clip:rect(0,0,0,0);height:1px;margin:-1px;overflow:hidden;padding:0;position:absolute;width:1px}.sr-only-focusable:active,.sr-only-focusable:focus{clip:auto;height:auto;margin:0;overflow:visible;position:static;width:auto}@font-face{font-family:Font Awesome\ 5 Brands;font-style:normal;font-weight:400;src:url(fa-brands-400.eot);src:url(fa-brands-400.eot?#iefix) format("embedded-opentype"),url(fa-brands-400.woff2) format("woff2"),url(fa-brands-400.woff) format("woff"),url(fa-brands-400.ttf) format("truetype"),url(fa-brands-400.svg#fontawesome) format("svg")}.fab{font-family:Font Awesome\ 5 Brands}@font-face{font-family:Font Awesome\ 5 Free;font-style:normal;font-weight:400;src:url(fa-regular-400.eot);src:url(fa-regular-400.eot?#iefix) format("embedded-opentype"),url(fa-regular-400.woff2) format("woff2"),url(fa-regular-400.woff) format("woff"),url(fa-regular-400.ttf) format("truetype"),url(fa-regular-400.svg#fontawesome) format("svg")}.far{font-weight:400}@font-face{font-family:Font Awesome\ 5 Free;font-style:normal;font-weight:900;src:url(fa-solid-900.eot);src:url(fa-solid-900.eot?#iefix) format("embedded-opentype"),url(fa-solid-900.woff2) format("woff2"),url(fa-solid-900.woff) format("woff"),url(fa-solid-900.ttf) format("truetype"),url(fa-solid-900.svg#fontawesome) format("svg")}.fa,.far,.fas{font-family:Font Awesome\ 5 Free}.fa,.fas{font-weight:900}.shariff:after,.shariff:before{content:" ";display:table}.shariff:after{clear:both}.shariff ul{padding:0;margin:0;list-style:none}.shariff li{overflow:hidden}.shariff li,.shariff li a{height:35px;-webkit-box-sizing:border-box;box-sizing:border-box}.shariff li a{color:#fff;position:relative;display:block;text-decoration:none}.shariff li .share_count,.shariff li .share_text{font-family:Arial,Helvetica,sans-serif;font-size:12px;vertical-align:middle;line-height:35px}.shariff li .fab,.shariff li .far,.shariff li .fas{width:35px;line-height:35px;text-align:center;vertical-align:middle}.shariff li .share_count{padding:0 8px;height:33px;position:absolute;top:1px;right:1px}.shariff .orientation-horizontal li{-webkit-box-flex:1}.shariff .orientation-horizontal .info{-webkit-box-flex:0}.shariff .orientation-horizontal{display:-webkit-box;display:-ms-flexbox;display:flex;-ms-flex-wrap:wrap;flex-wrap:wrap}.shariff .orientation-horizontal li{float:left;-webkit-box-flex:0;-ms-flex:none;flex:none;width:35px;margin-right:3%;margin-bottom:10px}.shariff .orientation-horizontal li:last-child{margin-right:0}.shariff .orientation-horizontal li .share_text{display:block;text-indent:-9999px;padding-left:3px}.shariff .orientation-horizontal li .share_count{display:none}.shariff .theme-grey .shariff-button a{background-color:#b0b0b0}.shariff .theme-grey .shariff-button .share_count{background-color:#ccc;color:#333}.shariff .theme-white .shariff-button{border:1px solid #ddd}.shariff .theme-white .shariff-button a{background-color:#fff}.shariff .theme-white .shariff-button a:hover{background-color:#eee}.shariff .theme-white .shariff-button .share_count{background-color:#fff;color:#999}.shariff .orientation-vertical.button-style-icon{min-width:35px}.shariff .orientation-vertical.button-style-icon-count{min-width:80px}.shariff .orientation-vertical.button-style-standard{min-width:110px}.shariff .orientation-vertical li{display:block;width:100%;margin:5px 0}.shariff .orientation-vertical.button-style-icon-count li .share_count,.shariff .orientation-vertical.button-style-standard li .share_count{width:24px;text-align:right}@media only screen and (min-width:360px){.shariff .orientation-horizontal li{margin-right:1.8%}.shariff .orientation-horizontal.button-style-icon-count li,.shariff .orientation-horizontal.button-style-standard li{min-width:80px}.shariff .orientation-horizontal.button-style-icon-count li .share_count,.shariff .orientation-horizontal.button-style-standard li .share_count{display:block}.shariff .orientation-horizontal.button-style-standard li{width:auto;-webkit-box-flex:1;-ms-flex:1 0 auto;flex:1 0 auto}.shariff .orientation-horizontal.button-style-standard.shariff-col-1 li,.shariff .orientation-horizontal.button-style-standard.shariff-col-2 li{min-width:110px;max-width:160px}.shariff .orientation-horizontal.button-style-standard.shariff-col-1 li .share_text,.shariff .orientation-horizontal.button-style-standard.shariff-col-2 li .share_text{text-indent:0;display:inline}.shariff .orientation-horizontal.button-style-standard.shariff-col-5 li,.shariff .orientation-horizontal.button-style-standard.shariff-col-6 li{-webkit-box-flex:0;-ms-flex:none;flex:none}}@media only screen and (min-width:640px){.shariff .orientation-horizontal.button-style-standard.shariff-col-3 li{min-width:110px;max-width:160px}.shariff .orientation-horizontal.button-style-standard.shariff-col-3 li .share_text{text-indent:0;display:inline}}@media only screen and (min-width:768px){.shariff .orientation-horizontal.button-style-standard li{min-width:110px;max-width:160px}.shariff .orientation-horizontal.button-style-standard li .share_text{text-indent:0;display:inline}.shariff .orientation-horizontal.button-style-standard.shariff-col-5 li,.shariff .orientation-horizontal.button-style-standard.shariff-col-6 li{-webkit-box-flex:1;-ms-flex:1 0 auto;flex:1 0 auto}}@media only screen and (min-width:1024px){.shariff li,.shariff li a{height:30px}.shariff li .fab,.shariff li .far,.shariff li .fas{width:30px;line-height:30px}.shariff li .share_count,.shariff li .share_text{line-height:30px}.shariff li .share_count{height:28px}}.shariff .addthis a{background-color:#f8694d}.shariff .addthis a:hover{background-color:#f75b44}.shariff .addthis .fa-plus{font-size:14px}.shariff .addthis .share_count{color:#f8694d;background-color:#f1b8b0}.shariff .theme-white .addthis a{color:#f8694d}@media only screen and (min-width:600px){.shariff .addthis .fa-plus{font-size:14px;position:relative;top:1px}}.shariff .diaspora a{background-color:#999}.shariff .diaspora a:hover{background-color:#b3b3b3}.shariff .diaspora .fa-times-circle{font-size:17px}.shariff .theme-white .diaspora a{color:#999}@media only screen and (min-width:600px){.shariff .diaspora .fa-times-circle{font-size:16px}}.shariff .facebook a{background-color:#3b5998}.shariff .facebook a:hover{background-color:#4273c8}.shariff .facebook .fa-facebook-f{font-size:22px}.shariff .facebook .share_count{color:#183a75;background-color:#99adcf}.shariff .theme-white .facebook a{color:#3b5998}@media only screen and (min-width:600px){.shariff .facebook .fa-facebook-f{font-size:19px}}.shariff .flattr a{background-color:#7ea352}.shariff .flattr a:hover{background-color:#f67c1a}.shariff .flattr a:hover .share_count{color:#d56308;background-color:#fab47c}.shariff .flattr .fa-money-bill-alt{font-size:22px}.shariff .flattr .share_count{color:#648141;background-color:#b0c893}.shariff .theme-white .flattr a{color:#f67c1a}@media only screen and (min-width:600px){.shariff .flattr .fa-money-bill-alt{font-size:19px}}.shariff .flipboard a{background-color:#e12828}.shariff .flipboard a:hover{background-color:#ff2e2e}.shariff .flipboard .fa-flipboard{font-size:22px}.shariff .theme-white .flipboard a{color:#e12828}@media only screen and (min-width:600px){.shariff .flipboard .fa-flipboard{font-size:19px}}.shariff .googleplus a{background-color:#d34836}.shariff .googleplus a:hover{background-color:#f75b44}.shariff .googleplus .fa-google-plus-g{font-size:22px}.shariff .googleplus .share_count{color:#a31601;background-color:#eda79d}.shariff .theme-white .googleplus a{color:#d34836}@media only screen and (min-width:600px){.shariff .googleplus .fa-google-plus-g{font-size:19px}}.shariff .info{border:1px solid #ccc}.shariff .info a{color:#666;background-color:#fff}.shariff .info a:hover{background-color:#efefef}.shariff .info .fa-info{font-size:20px;width:33px}.shariff .info .share_text{display:block!important;text-indent:-9999px!important}.shariff .theme-grey .info a{background-color:#fff}.shariff .theme-grey .info a:hover{background-color:#efefef}.shariff .orientation-vertical .info{width:35px;float:right}@media only screen and (min-width:360px){.shariff .orientation-horizontal .info{-webkit-box-flex:0!important;-ms-flex:none!important;flex:none!important;width:35px;min-width:35px!important}}@media only screen and (min-width:1024px){.shariff .info .fa-info{font-size:16px;width:23px}.shariff .orientation-horizontal .info{width:25px;min-width:25px!important}.shariff .orientation-vertical .info{width:25px}}.shariff .linkedin a{background-color:#0077b5}.shariff .linkedin a:hover{background-color:#0369a0}.shariff .linkedin .fa-linkedin-in{font-size:22px}.shariff .linkedin .share_count{color:#004785;background-color:#33aae8}.shariff .theme-white .linkedin a{color:#0077b5}@media only screen and (min-width:600px){.shariff .linkedin .fa-linkedin-in{font-size:19px}}.shariff .mail a{background-color:#999}.shariff .mail a:hover{background-color:#a8a8a8}.shariff .mail .fa-envelope{font-size:21px}.shariff .theme-white .mail a{color:#999}@media only screen and (min-width:600px){.shariff .mail .fa-envelope{font-size:18px}}.shariff .print a{background-color:#999}.shariff .print a:hover{background-color:#a8a8a8}.shariff .print .fa-print{font-size:21px}.shariff .theme-white .print a{color:#999}@media only screen and (min-width:600px){.shariff .print .fa-print{font-size:18px}}.shariff .pinterest a{background-color:#bd081c}.shariff .pinterest a:hover{background-color:#d50920}.shariff .pinterest .fa-pinterest-p{font-size:22px}.shariff .pinterest .share_count{color:#a31601;background-color:#eda79d}.shariff .theme-white .pinterest a{color:#bd081c}@media only screen and (min-width:600px){.shariff .pinterest .fa-pinterest-p{font-size:19px;position:relative;top:1px}}.shariff .reddit a{background-color:#ff4500}.shariff .reddit a:hover{background-color:#ff6a33}.shariff .reddit .fa-reddit{font-size:17px}.shariff .theme-white .reddit a{color:#ff4500}@media only screen and (min-width:600px){.shariff .reddit .fa-reddit{font-size:16px}}.shariff .stumbleupon a{background-color:#eb4924}.shariff .stumbleupon a:hover{background-color:#ef7053}.shariff .stumbleupon .fa-stumbleupon{font-size:17px}.shariff .theme-white .stumbleupon a{color:#eb4924}@media only screen and (min-width:600px){.shariff .stumbleupon .fa-stumbleupon{font-size:16px}}.shariff .twitter a{background-color:#55acee}.shariff .twitter a:hover{background-color:#32bbf5}.shariff .twitter .fa-twitter{font-size:28px}.shariff .twitter .share_count{color:#0174a4;background-color:#96d4ee}.shariff .theme-white .twitter a{color:#55acee}@media only screen and (min-width:600px){.shariff .twitter .fa-twitter{font-size:24px}}.shariff .whatsapp a{background-color:#5cbe4a}.shariff .whatsapp a:hover{background-color:#34af23}.shariff .whatsapp .fa-whatsapp{font-size:28px}.shariff .theme-white .whatsapp a{color:#5cbe4a}@media only screen and (min-width:600px){.shariff .whatsapp .fa-whatsapp{font-size:22px}}.shariff .xing a{background-color:#126567}.shariff .xing a:hover{background-color:#29888a}.shariff .xing .fa-xing{font-size:22px}.shariff .xing .share_count{color:#15686a;background-color:#4fa5a7}.shariff .theme-white .xing a{color:#126567}@media only screen and (min-width:600px){.shariff .xing .fa-xing{font-size:19px}}.shariff .tumblr a{background-color:#36465d}.shariff .tumblr a:hover{background-color:#44546b}.shariff .tumblr .fa-tumblr{font-size:28px}.shariff .theme-white .tumblr a{color:#5cbe4a}@media only screen and (min-width:600px){.shariff .tumblr .fa-tumblr{font-size:22px}}.shariff .threema a{background-color:#333}.shariff .threema a:hover{background-color:#1f1f1f}.shariff .threema .fa-lock{font-size:28px}.shariff .theme-white .threema a{color:#333}@media only screen and (min-width:600px){.shariff .threema .fa-lock{font-size:22px}}.shariff .weibo a{background-color:#f56770}.shariff .weibo a:hover{background-color:#fa7f8a}.shariff .weibo .fa-weibo{font-size:28px}.shariff .weibo .share_count{color:#0174a4;background-color:#f56770}.shariff .theme-white .weibo a{color:#f56770}@media only screen and (min-width:600px){.shariff .weibo .fa-weibo{font-size:24px}}.shariff .tencent-weibo a{background-color:#26ace0}.shariff .tencent-weibo a:hover{background-color:#38bbeb}.shariff .tencent-weibo .fa-tencent-weibo{font-size:28px}.shariff .tencent-weibo .share_count{color:#0174a4;background-color:#26ace0}.shariff .theme-white .tencent-weibo a{color:#26ace0}@media only screen and (min-width:600px){.shariff .tencent-weibo .fa-tencent-weibo{font-size:24px}}.shariff .telegram a{background-color:#08c}.shariff .telegram a:hover{background-color:#007dbb}.shariff .telegram .fa-telegram{font-size:28px}.shariff .theme-white .telegram a{color:#08c}@media only screen and (min-width:600px){.shariff .telegram .fa-telegram{font-size:22px}}.shariff .qzone a{background-color:#2b82d9}.shariff .qzone a:hover{background-color:#398fe6}.shariff .qzone .fa-qq{font-size:28px}.shariff .qzone .share_count{color:#0174a4;background-color:#2b82d9}.shariff .theme-white .qzone a{color:#2b82d9}@media only screen and (min-width:600px){.shariff .qzone .fa-qq{font-size:24px}}.shariff .vk a{background-color:#5d7fa4}.shariff .vk a:hover{background-color:#678eb4}.shariff .vk .fa-vk{font-size:22px}.shariff .vk .share_count{color:#55677d;background-color:#fff}.shariff .theme-white .vk a{color:#3b5998}@media only screen and (min-width:600px){.shariff .vk .fa-vk{font-size:19px}}
+ */
+.fa,
+.fab,
+.fal,
+.far,
+.fas {
+	-moz-osx-font-smoothing: grayscale;
+	-webkit-font-smoothing: antialiased;
+	display: inline-block;
+	font-style: normal;
+	font-variant: normal;
+	text-rendering: auto;
+	line-height: 1
+}
+
+.fa-lg {
+	font-size: 1.33333333em;
+	line-height: .75em;
+	vertical-align: -.0667em
+}
+
+.fa-xs {
+	font-size: .75em
+}
+
+.fa-sm {
+	font-size: .875em
+}
+
+.fa-1x {
+	font-size: 1em
+}
+
+.fa-2x {
+	font-size: 2em
+}
+
+.fa-3x {
+	font-size: 3em
+}
+
+.fa-4x {
+	font-size: 4em
+}
+
+.fa-5x {
+	font-size: 5em
+}
+
+.fa-6x {
+	font-size: 6em
+}
+
+.fa-7x {
+	font-size: 7em
+}
+
+.fa-8x {
+	font-size: 8em
+}
+
+.fa-9x {
+	font-size: 9em
+}
+
+.fa-10x {
+	font-size: 10em
+}
+
+.fa-fw {
+	text-align: center;
+	width: 1.25em
+}
+
+.fa-ul {
+	list-style-type: none;
+	margin-left: 2em * 5/4;
+	padding-left: 0
+}
+
+.fa-ul>li {
+	position: relative
+}
+
+.fa-li {
+	left: -2em;
+	position: absolute;
+	text-align: center;
+	width: 2em;
+	line-height: inherit
+}
+
+.fa-border {
+	border-radius: .1em;
+	border: .08em solid #eee;
+	padding: .2em .25em .15em
+}
+
+.fa-pull-left {
+	float: left
+}
+
+.fa-pull-right {
+	float: right
+}
+
+.fa.fa-pull-left,
+.fab.fa-pull-left,
+.fal.fa-pull-left,
+.far.fa-pull-left,
+.fas.fa-pull-left {
+	margin-right: .3em
+}
+
+.fa.fa-pull-right,
+.fab.fa-pull-right,
+.fal.fa-pull-right,
+.far.fa-pull-right,
+.fas.fa-pull-right {
+	margin-left: .3em
+}
+
+.fa-spin {
+	-webkit-animation: fa-spin 2s infinite linear;
+	animation: fa-spin 2s infinite linear
+}
+
+.fa-pulse {
+	-webkit-animation: fa-spin 1s infinite steps(8);
+	animation: fa-spin 1s infinite steps(8)
+}
+
+@-webkit-keyframes fa-spin {
+	0% {
+		-webkit-transform: rotate(0deg);
+		transform: rotate(0deg)
+	}
+	to {
+		-webkit-transform: rotate(1turn);
+		transform: rotate(1turn)
+	}
+}
+
+@keyframes fa-spin {
+	0% {
+		-webkit-transform: rotate(0deg);
+		transform: rotate(0deg)
+	}
+	to {
+		-webkit-transform: rotate(1turn);
+		transform: rotate(1turn)
+	}
+}
+
+.fa-rotate-90 {
+	-ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=1)";
+	-webkit-transform: rotate(90deg);
+	transform: rotate(90deg)
+}
+
+.fa-rotate-180 {
+	-ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=2)";
+	-webkit-transform: rotate(180deg);
+	transform: rotate(180deg)
+}
+
+.fa-rotate-270 {
+	-ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=3)";
+	-webkit-transform: rotate(270deg);
+	transform: rotate(270deg)
+}
+
+.fa-flip-horizontal {
+	-ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=0, mirror=1)";
+	-webkit-transform: scaleX(-1);
+	transform: scaleX(-1)
+}
+
+.fa-flip-vertical {
+	-webkit-transform: scaleY(-1);
+	transform: scaleY(-1)
+}
+
+.fa-flip-horizontal.fa-flip-vertical,
+.fa-flip-vertical {
+	-ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=2, mirror=1)"
+}
+
+.fa-flip-horizontal.fa-flip-vertical {
+	-webkit-transform: scale(-1);
+	transform: scale(-1)
+}
+
+:root .fa-flip-horizontal,
+:root .fa-flip-vertical,
+:root .fa-rotate-90,
+:root .fa-rotate-180,
+:root .fa-rotate-270 {
+	-webkit-filter: none;
+	filter: none
+}
+
+.fa-stack {
+	display: inline-block;
+	height: 2em;
+	line-height: 2em;
+	position: relative;
+	vertical-align: middle;
+	width: 2em
+}
+
+.fa-stack-1x,
+.fa-stack-2x {
+	left: 0;
+	position: absolute;
+	text-align: center;
+	width: 100%
+}
+
+.fa-stack-1x {
+	line-height: inherit
+}
+
+.fa-stack-2x {
+	font-size: 2em
+}
+
+.fa-inverse {
+	color: #fff
+}
+
+.fa-500px:before {
+	content: "\F26E"
+}
+
+.fa-accessible-icon:before {
+	content: "\F368"
+}
+
+.fa-accusoft:before {
+	content: "\F369"
+}
+
+.fa-address-book:before {
+	content: "\F2B9"
+}
+
+.fa-address-card:before {
+	content: "\F2BB"
+}
+
+.fa-adjust:before {
+	content: "\F042"
+}
+
+.fa-adn:before {
+	content: "\F170"
+}
+
+.fa-adversal:before {
+	content: "\F36A"
+}
+
+.fa-affiliatetheme:before {
+	content: "\F36B"
+}
+
+.fa-algolia:before {
+	content: "\F36C"
+}
+
+.fa-align-center:before {
+	content: "\F037"
+}
+
+.fa-align-justify:before {
+	content: "\F039"
+}
+
+.fa-align-left:before {
+	content: "\F036"
+}
+
+.fa-align-right:before {
+	content: "\F038"
+}
+
+.fa-amazon:before {
+	content: "\F270"
+}
+
+.fa-amazon-pay:before {
+	content: "\F42C"
+}
+
+.fa-ambulance:before {
+	content: "\F0F9"
+}
+
+.fa-american-sign-language-interpreting:before {
+	content: "\F2A3"
+}
+
+.fa-amilia:before {
+	content: "\F36D"
+}
+
+.fa-anchor:before {
+	content: "\F13D"
+}
+
+.fa-android:before {
+	content: "\F17B"
+}
+
+.fa-angellist:before {
+	content: "\F209"
+}
+
+.fa-angle-double-down:before {
+	content: "\F103"
+}
+
+.fa-angle-double-left:before {
+	content: "\F100"
+}
+
+.fa-angle-double-right:before {
+	content: "\F101"
+}
+
+.fa-angle-double-up:before {
+	content: "\F102"
+}
+
+.fa-angle-down:before {
+	content: "\F107"
+}
+
+.fa-angle-left:before {
+	content: "\F104"
+}
+
+.fa-angle-right:before {
+	content: "\F105"
+}
+
+.fa-angle-up:before {
+	content: "\F106"
+}
+
+.fa-angrycreative:before {
+	content: "\F36E"
+}
+
+.fa-angular:before {
+	content: "\F420"
+}
+
+.fa-app-store:before {
+	content: "\F36F"
+}
+
+.fa-app-store-ios:before {
+	content: "\F370"
+}
+
+.fa-apper:before {
+	content: "\F371"
+}
+
+.fa-apple:before {
+	content: "\F179"
+}
+
+.fa-apple-pay:before {
+	content: "\F415"
+}
+
+.fa-archive:before {
+	content: "\F187"
+}
+
+.fa-arrow-alt-circle-down:before {
+	content: "\F358"
+}
+
+.fa-arrow-alt-circle-left:before {
+	content: "\F359"
+}
+
+.fa-arrow-alt-circle-right:before {
+	content: "\F35A"
+}
+
+.fa-arrow-alt-circle-up:before {
+	content: "\F35B"
+}
+
+.fa-arrow-circle-down:before {
+	content: "\F0AB"
+}
+
+.fa-arrow-circle-left:before {
+	content: "\F0A8"
+}
+
+.fa-arrow-circle-right:before {
+	content: "\F0A9"
+}
+
+.fa-arrow-circle-up:before {
+	content: "\F0AA"
+}
+
+.fa-arrow-down:before {
+	content: "\F063"
+}
+
+.fa-arrow-left:before {
+	content: "\F060"
+}
+
+.fa-arrow-right:before {
+	content: "\F061"
+}
+
+.fa-arrow-up:before {
+	content: "\F062"
+}
+
+.fa-arrows-alt:before {
+	content: "\F0B2"
+}
+
+.fa-arrows-alt-h:before {
+	content: "\F337"
+}
+
+.fa-arrows-alt-v:before {
+	content: "\F338"
+}
+
+.fa-assistive-listening-systems:before {
+	content: "\F2A2"
+}
+
+.fa-asterisk:before {
+	content: "\F069"
+}
+
+.fa-asymmetrik:before {
+	content: "\F372"
+}
+
+.fa-at:before {
+	content: "\F1FA"
+}
+
+.fa-audible:before {
+	content: "\F373"
+}
+
+.fa-audio-description:before {
+	content: "\F29E"
+}
+
+.fa-autoprefixer:before {
+	content: "\F41C"
+}
+
+.fa-avianex:before {
+	content: "\F374"
+}
+
+.fa-aviato:before {
+	content: "\F421"
+}
+
+.fa-aws:before {
+	content: "\F375"
+}
+
+.fa-backward:before {
+	content: "\F04A"
+}
+
+.fa-balance-scale:before {
+	content: "\F24E"
+}
+
+.fa-ban:before {
+	content: "\F05E"
+}
+
+.fa-bandcamp:before {
+	content: "\F2D5"
+}
+
+.fa-barcode:before {
+	content: "\F02A"
+}
+
+.fa-bars:before {
+	content: "\F0C9"
+}
+
+.fa-baseball-ball:before {
+	content: "\F433"
+}
+
+.fa-basketball-ball:before {
+	content: "\F434"
+}
+
+.fa-bath:before {
+	content: "\F2CD"
+}
+
+.fa-battery-empty:before {
+	content: "\F244"
+}
+
+.fa-battery-full:before {
+	content: "\F240"
+}
+
+.fa-battery-half:before {
+	content: "\F242"
+}
+
+.fa-battery-quarter:before {
+	content: "\F243"
+}
+
+.fa-battery-three-quarters:before {
+	content: "\F241"
+}
+
+.fa-bed:before {
+	content: "\F236"
+}
+
+.fa-beer:before {
+	content: "\F0FC"
+}
+
+.fa-behance:before {
+	content: "\F1B4"
+}
+
+.fa-behance-square:before {
+	content: "\F1B5"
+}
+
+.fa-bell:before {
+	content: "\F0F3"
+}
+
+.fa-bell-slash:before {
+	content: "\F1F6"
+}
+
+.fa-bicycle:before {
+	content: "\F206"
+}
+
+.fa-bimobject:before {
+	content: "\F378"
+}
+
+.fa-binoculars:before {
+	content: "\F1E5"
+}
+
+.fa-birthday-cake:before {
+	content: "\F1FD"
+}
+
+.fa-bitbucket:before {
+	content: "\F171"
+}
+
+.fa-bitcoin:before {
+	content: "\F379"
+}
+
+.fa-bity:before {
+	content: "\F37A"
+}
+
+.fa-black-tie:before {
+	content: "\F27E"
+}
+
+.fa-blackberry:before {
+	content: "\F37B"
+}
+
+.fa-blind:before {
+	content: "\F29D"
+}
+
+.fa-blogger:before {
+	content: "\F37C"
+}
+
+.fa-blogger-b:before {
+	content: "\F37D"
+}
+
+.fa-bluetooth:before {
+	content: "\F293"
+}
+
+.fa-bluetooth-b:before {
+	content: "\F294"
+}
+
+.fa-bold:before {
+	content: "\F032"
+}
+
+.fa-bolt:before {
+	content: "\F0E7"
+}
+
+.fa-bomb:before {
+	content: "\F1E2"
+}
+
+.fa-book:before {
+	content: "\F02D"
+}
+
+.fa-bookmark:before {
+	content: "\F02E"
+}
+
+.fa-bowling-ball:before {
+	content: "\F436"
+}
+
+.fa-braille:before {
+	content: "\F2A1"
+}
+
+.fa-briefcase:before {
+	content: "\F0B1"
+}
+
+.fa-btc:before {
+	content: "\F15A"
+}
+
+.fa-bug:before {
+	content: "\F188"
+}
+
+.fa-building:before {
+	content: "\F1AD"
+}
+
+.fa-bullhorn:before {
+	content: "\F0A1"
+}
+
+.fa-bullseye:before {
+	content: "\F140"
+}
+
+.fa-buromobelexperte:before {
+	content: "\F37F"
+}
+
+.fa-bus:before {
+	content: "\F207"
+}
+
+.fa-buysellads:before {
+	content: "\F20D"
+}
+
+.fa-calculator:before {
+	content: "\F1EC"
+}
+
+.fa-calendar:before {
+	content: "\F133"
+}
+
+.fa-calendar-alt:before {
+	content: "\F073"
+}
+
+.fa-calendar-check:before {
+	content: "\F274"
+}
+
+.fa-calendar-minus:before {
+	content: "\F272"
+}
+
+.fa-calendar-plus:before {
+	content: "\F271"
+}
+
+.fa-calendar-times:before {
+	content: "\F273"
+}
+
+.fa-camera:before {
+	content: "\F030"
+}
+
+.fa-camera-retro:before {
+	content: "\F083"
+}
+
+.fa-car:before {
+	content: "\F1B9"
+}
+
+.fa-caret-down:before {
+	content: "\F0D7"
+}
+
+.fa-caret-left:before {
+	content: "\F0D9"
+}
+
+.fa-caret-right:before {
+	content: "\F0DA"
+}
+
+.fa-caret-square-down:before {
+	content: "\F150"
+}
+
+.fa-caret-square-left:before {
+	content: "\F191"
+}
+
+.fa-caret-square-right:before {
+	content: "\F152"
+}
+
+.fa-caret-square-up:before {
+	content: "\F151"
+}
+
+.fa-caret-up:before {
+	content: "\F0D8"
+}
+
+.fa-cart-arrow-down:before {
+	content: "\F218"
+}
+
+.fa-cart-plus:before {
+	content: "\F217"
+}
+
+.fa-cc-amazon-pay:before {
+	content: "\F42D"
+}
+
+.fa-cc-amex:before {
+	content: "\F1F3"
+}
+
+.fa-cc-apple-pay:before {
+	content: "\F416"
+}
+
+.fa-cc-diners-club:before {
+	content: "\F24C"
+}
+
+.fa-cc-discover:before {
+	content: "\F1F2"
+}
+
+.fa-cc-jcb:before {
+	content: "\F24B"
+}
+
+.fa-cc-mastercard:before {
+	content: "\F1F1"
+}
+
+.fa-cc-paypal:before {
+	content: "\F1F4"
+}
+
+.fa-cc-stripe:before {
+	content: "\F1F5"
+}
+
+.fa-cc-visa:before {
+	content: "\F1F0"
+}
+
+.fa-centercode:before {
+	content: "\F380"
+}
+
+.fa-certificate:before {
+	content: "\F0A3"
+}
+
+.fa-chart-area:before {
+	content: "\F1FE"
+}
+
+.fa-chart-bar:before {
+	content: "\F080"
+}
+
+.fa-chart-line:before {
+	content: "\F201"
+}
+
+.fa-chart-pie:before {
+	content: "\F200"
+}
+
+.fa-check:before {
+	content: "\F00C"
+}
+
+.fa-check-circle:before {
+	content: "\F058"
+}
+
+.fa-check-square:before {
+	content: "\F14A"
+}
+
+.fa-chess:before {
+	content: "\F439"
+}
+
+.fa-chess-bishop:before {
+	content: "\F43A"
+}
+
+.fa-chess-board:before {
+	content: "\F43C"
+}
+
+.fa-chess-king:before {
+	content: "\F43F"
+}
+
+.fa-chess-knight:before {
+	content: "\F441"
+}
+
+.fa-chess-pawn:before {
+	content: "\F443"
+}
+
+.fa-chess-queen:before {
+	content: "\F445"
+}
+
+.fa-chess-rook:before {
+	content: "\F447"
+}
+
+.fa-chevron-circle-down:before {
+	content: "\F13A"
+}
+
+.fa-chevron-circle-left:before {
+	content: "\F137"
+}
+
+.fa-chevron-circle-right:before {
+	content: "\F138"
+}
+
+.fa-chevron-circle-up:before {
+	content: "\F139"
+}
+
+.fa-chevron-down:before {
+	content: "\F078"
+}
+
+.fa-chevron-left:before {
+	content: "\F053"
+}
+
+.fa-chevron-right:before {
+	content: "\F054"
+}
+
+.fa-chevron-up:before {
+	content: "\F077"
+}
+
+.fa-child:before {
+	content: "\F1AE"
+}
+
+.fa-chrome:before {
+	content: "\F268"
+}
+
+.fa-circle:before {
+	content: "\F111"
+}
+
+.fa-circle-notch:before {
+	content: "\F1CE"
+}
+
+.fa-clipboard:before {
+	content: "\F328"
+}
+
+.fa-clock:before {
+	content: "\F017"
+}
+
+.fa-clone:before {
+	content: "\F24D"
+}
+
+.fa-closed-captioning:before {
+	content: "\F20A"
+}
+
+.fa-cloud:before {
+	content: "\F0C2"
+}
+
+.fa-cloud-download-alt:before {
+	content: "\F381"
+}
+
+.fa-cloud-upload-alt:before {
+	content: "\F382"
+}
+
+.fa-cloudscale:before {
+	content: "\F383"
+}
+
+.fa-cloudsmith:before {
+	content: "\F384"
+}
+
+.fa-cloudversify:before {
+	content: "\F385"
+}
+
+.fa-code:before {
+	content: "\F121"
+}
+
+.fa-code-branch:before {
+	content: "\F126"
+}
+
+.fa-codepen:before {
+	content: "\F1CB"
+}
+
+.fa-codiepie:before {
+	content: "\F284"
+}
+
+.fa-coffee:before {
+	content: "\F0F4"
+}
+
+.fa-cog:before {
+	content: "\F013"
+}
+
+.fa-cogs:before {
+	content: "\F085"
+}
+
+.fa-columns:before {
+	content: "\F0DB"
+}
+
+.fa-comment:before {
+	content: "\F075"
+}
+
+.fa-comment-alt:before {
+	content: "\F27A"
+}
+
+.fa-comments:before {
+	content: "\F086"
+}
+
+.fa-compass:before {
+	content: "\F14E"
+}
+
+.fa-compress:before {
+	content: "\F066"
+}
+
+.fa-connectdevelop:before {
+	content: "\F20E"
+}
+
+.fa-contao:before {
+	content: "\F26D"
+}
+
+.fa-copy:before {
+	content: "\F0C5"
+}
+
+.fa-copyright:before {
+	content: "\F1F9"
+}
+
+.fa-cpanel:before {
+	content: "\F388"
+}
+
+.fa-creative-commons:before {
+	content: "\F25E"
+}
+
+.fa-credit-card:before {
+	content: "\F09D"
+}
+
+.fa-crop:before {
+	content: "\F125"
+}
+
+.fa-crosshairs:before {
+	content: "\F05B"
+}
+
+.fa-css3:before {
+	content: "\F13C"
+}
+
+.fa-css3-alt:before {
+	content: "\F38B"
+}
+
+.fa-cube:before {
+	content: "\F1B2"
+}
+
+.fa-cubes:before {
+	content: "\F1B3"
+}
+
+.fa-cut:before {
+	content: "\F0C4"
+}
+
+.fa-cuttlefish:before {
+	content: "\F38C"
+}
+
+.fa-d-and-d:before {
+	content: "\F38D"
+}
+
+.fa-dashcube:before {
+	content: "\F210"
+}
+
+.fa-database:before {
+	content: "\F1C0"
+}
+
+.fa-deaf:before {
+	content: "\F2A4"
+}
+
+.fa-delicious:before {
+	content: "\F1A5"
+}
+
+.fa-deploydog:before {
+	content: "\F38E"
+}
+
+.fa-deskpro:before {
+	content: "\F38F"
+}
+
+.fa-desktop:before {
+	content: "\F108"
+}
+
+.fa-deviantart:before {
+	content: "\F1BD"
+}
+
+.fa-digg:before {
+	content: "\F1A6"
+}
+
+.fa-digital-ocean:before {
+	content: "\F391"
+}
+
+.fa-discord:before {
+	content: "\F392"
+}
+
+.fa-discourse:before {
+	content: "\F393"
+}
+
+.fa-dochub:before {
+	content: "\F394"
+}
+
+.fa-docker:before {
+	content: "\F395"
+}
+
+.fa-dollar-sign:before {
+	content: "\F155"
+}
+
+.fa-dot-circle:before {
+	content: "\F192"
+}
+
+.fa-download:before {
+	content: "\F019"
+}
+
+.fa-draft2digital:before {
+	content: "\F396"
+}
+
+.fa-dribbble:before {
+	content: "\F17D"
+}
+
+.fa-dribbble-square:before {
+	content: "\F397"
+}
+
+.fa-dropbox:before {
+	content: "\F16B"
+}
+
+.fa-drupal:before {
+	content: "\F1A9"
+}
+
+.fa-dyalog:before {
+	content: "\F399"
+}
+
+.fa-earlybirds:before {
+	content: "\F39A"
+}
+
+.fa-edge:before {
+	content: "\F282"
+}
+
+.fa-edit:before {
+	content: "\F044"
+}
+
+.fa-eject:before {
+	content: "\F052"
+}
+
+.fa-elementor:before {
+	content: "\F430"
+}
+
+.fa-ellipsis-h:before {
+	content: "\F141"
+}
+
+.fa-ellipsis-v:before {
+	content: "\F142"
+}
+
+.fa-ember:before {
+	content: "\F423"
+}
+
+.fa-empire:before {
+	content: "\F1D1"
+}
+
+.fa-envelope:before {
+	content: "\F0E0"
+}
+
+.fa-envelope-open:before {
+	content: "\F2B6"
+}
+
+.fa-envelope-square:before {
+	content: "\F199"
+}
+
+.fa-envira:before {
+	content: "\F299"
+}
+
+.fa-eraser:before {
+	content: "\F12D"
+}
+
+.fa-erlang:before {
+	content: "\F39D"
+}
+
+.fa-ethereum:before {
+	content: "\F42E"
+}
+
+.fa-etsy:before {
+	content: "\F2D7"
+}
+
+.fa-euro-sign:before {
+	content: "\F153"
+}
+
+.fa-exchange-alt:before {
+	content: "\F362"
+}
+
+.fa-exclamation:before {
+	content: "\F12A"
+}
+
+.fa-exclamation-circle:before {
+	content: "\F06A"
+}
+
+.fa-exclamation-triangle:before {
+	content: "\F071"
+}
+
+.fa-expand:before {
+	content: "\F065"
+}
+
+.fa-expand-arrows-alt:before {
+	content: "\F31E"
+}
+
+.fa-expeditedssl:before {
+	content: "\F23E"
+}
+
+.fa-external-link-alt:before {
+	content: "\F35D"
+}
+
+.fa-external-link-square-alt:before {
+	content: "\F360"
+}
+
+.fa-eye:before {
+	content: "\F06E"
+}
+
+.fa-eye-dropper:before {
+	content: "\F1FB"
+}
+
+.fa-eye-slash:before {
+	content: "\F070"
+}
+
+.fa-facebook:before {
+	content: "\F09A"
+}
+
+.fa-facebook-f:before {
+	content: "\F39E"
+}
+
+.fa-facebook-messenger:before {
+	content: "\F39F"
+}
+
+.fa-facebook-square:before {
+	content: "\F082"
+}
+
+.fa-fast-backward:before {
+	content: "\F049"
+}
+
+.fa-fast-forward:before {
+	content: "\F050"
+}
+
+.fa-fax:before {
+	content: "\F1AC"
+}
+
+.fa-female:before {
+	content: "\F182"
+}
+
+.fa-fighter-jet:before {
+	content: "\F0FB"
+}
+
+.fa-file:before {
+	content: "\F15B"
+}
+
+.fa-file-alt:before {
+	content: "\F15C"
+}
+
+.fa-file-archive:before {
+	content: "\F1C6"
+}
+
+.fa-file-audio:before {
+	content: "\F1C7"
+}
+
+.fa-file-code:before {
+	content: "\F1C9"
+}
+
+.fa-file-excel:before {
+	content: "\F1C3"
+}
+
+.fa-file-image:before {
+	content: "\F1C5"
+}
+
+.fa-file-pdf:before {
+	content: "\F1C1"
+}
+
+.fa-file-powerpoint:before {
+	content: "\F1C4"
+}
+
+.fa-file-video:before {
+	content: "\F1C8"
+}
+
+.fa-file-word:before {
+	content: "\F1C2"
+}
+
+.fa-film:before {
+	content: "\F008"
+}
+
+.fa-filter:before {
+	content: "\F0B0"
+}
+
+.fa-fire:before {
+	content: "\F06D"
+}
+
+.fa-fire-extinguisher:before {
+	content: "\F134"
+}
+
+.fa-firefox:before {
+	content: "\F269"
+}
+
+.fa-first-order:before {
+	content: "\F2B0"
+}
+
+.fa-firstdraft:before {
+	content: "\F3A1"
+}
+
+.fa-flag:before {
+	content: "\F024"
+}
+
+.fa-flag-checkered:before {
+	content: "\F11E"
+}
+
+.fa-flask:before {
+	content: "\F0C3"
+}
+
+.fa-flickr:before {
+	content: "\F16E"
+}
+
+.fa-flipboard:before {
+	content: "\F44D"
+}
+
+.fa-fly:before {
+	content: "\F417"
+}
+
+.fa-folder:before {
+	content: "\F07B"
+}
+
+.fa-folder-open:before {
+	content: "\F07C"
+}
+
+.fa-font:before {
+	content: "\F031"
+}
+
+.fa-font-awesome:before {
+	content: "\F2B4"
+}
+
+.fa-font-awesome-alt:before {
+	content: "\F35C"
+}
+
+.fa-font-awesome-flag:before {
+	content: "\F425"
+}
+
+.fa-fonticons:before {
+	content: "\F280"
+}
+
+.fa-fonticons-fi:before {
+	content: "\F3A2"
+}
+
+.fa-football-ball:before {
+	content: "\F44E"
+}
+
+.fa-fort-awesome:before {
+	content: "\F286"
+}
+
+.fa-fort-awesome-alt:before {
+	content: "\F3A3"
+}
+
+.fa-forumbee:before {
+	content: "\F211"
+}
+
+.fa-forward:before {
+	content: "\F04E"
+}
+
+.fa-foursquare:before {
+	content: "\F180"
+}
+
+.fa-free-code-camp:before {
+	content: "\F2C5"
+}
+
+.fa-freebsd:before {
+	content: "\F3A4"
+}
+
+.fa-frown:before {
+	content: "\F119"
+}
+
+.fa-futbol:before {
+	content: "\F1E3"
+}
+
+.fa-gamepad:before {
+	content: "\F11B"
+}
+
+.fa-gavel:before {
+	content: "\F0E3"
+}
+
+.fa-gem:before {
+	content: "\F3A5"
+}
+
+.fa-genderless:before {
+	content: "\F22D"
+}
+
+.fa-get-pocket:before {
+	content: "\F265"
+}
+
+.fa-gg:before {
+	content: "\F260"
+}
+
+.fa-gg-circle:before {
+	content: "\F261"
+}
+
+.fa-gift:before {
+	content: "\F06B"
+}
+
+.fa-git:before {
+	content: "\F1D3"
+}
+
+.fa-git-square:before {
+	content: "\F1D2"
+}
+
+.fa-github:before {
+	content: "\F09B"
+}
+
+.fa-github-alt:before {
+	content: "\F113"
+}
+
+.fa-github-square:before {
+	content: "\F092"
+}
+
+.fa-gitkraken:before {
+	content: "\F3A6"
+}
+
+.fa-gitlab:before {
+	content: "\F296"
+}
+
+.fa-gitter:before {
+	content: "\F426"
+}
+
+.fa-glass-martini:before {
+	content: "\F000"
+}
+
+.fa-glide:before {
+	content: "\F2A5"
+}
+
+.fa-glide-g:before {
+	content: "\F2A6"
+}
+
+.fa-globe:before {
+	content: "\F0AC"
+}
+
+.fa-gofore:before {
+	content: "\F3A7"
+}
+
+.fa-golf-ball:before {
+	content: "\F450"
+}
+
+.fa-goodreads:before {
+	content: "\F3A8"
+}
+
+.fa-goodreads-g:before {
+	content: "\F3A9"
+}
+
+.fa-google:before {
+	content: "\F1A0"
+}
+
+.fa-google-drive:before {
+	content: "\F3AA"
+}
+
+.fa-google-play:before {
+	content: "\F3AB"
+}
+
+.fa-google-plus:before {
+	content: "\F2B3"
+}
+
+.fa-google-plus-g:before {
+	content: "\F0D5"
+}
+
+.fa-google-plus-square:before {
+	content: "\F0D4"
+}
+
+.fa-google-wallet:before {
+	content: "\F1EE"
+}
+
+.fa-graduation-cap:before {
+	content: "\F19D"
+}
+
+.fa-gratipay:before {
+	content: "\F184"
+}
+
+.fa-grav:before {
+	content: "\F2D6"
+}
+
+.fa-gripfire:before {
+	content: "\F3AC"
+}
+
+.fa-grunt:before {
+	content: "\F3AD"
+}
+
+.fa-gulp:before {
+	content: "\F3AE"
+}
+
+.fa-h-square:before {
+	content: "\F0FD"
+}
+
+.fa-hacker-news:before {
+	content: "\F1D4"
+}
+
+.fa-hacker-news-square:before {
+	content: "\F3AF"
+}
+
+.fa-hand-lizard:before {
+	content: "\F258"
+}
+
+.fa-hand-paper:before {
+	content: "\F256"
+}
+
+.fa-hand-peace:before {
+	content: "\F25B"
+}
+
+.fa-hand-point-down:before {
+	content: "\F0A7"
+}
+
+.fa-hand-point-left:before {
+	content: "\F0A5"
+}
+
+.fa-hand-point-right:before {
+	content: "\F0A4"
+}
+
+.fa-hand-point-up:before {
+	content: "\F0A6"
+}
+
+.fa-hand-pointer:before {
+	content: "\F25A"
+}
+
+.fa-hand-rock:before {
+	content: "\F255"
+}
+
+.fa-hand-scissors:before {
+	content: "\F257"
+}
+
+.fa-hand-spock:before {
+	content: "\F259"
+}
+
+.fa-handshake:before {
+	content: "\F2B5"
+}
+
+.fa-hashtag:before {
+	content: "\F292"
+}
+
+.fa-hdd:before {
+	content: "\F0A0"
+}
+
+.fa-heading:before {
+	content: "\F1DC"
+}
+
+.fa-headphones:before {
+	content: "\F025"
+}
+
+.fa-heart:before {
+	content: "\F004"
+}
+
+.fa-heartbeat:before {
+	content: "\F21E"
+}
+
+.fa-hips:before {
+	content: "\F452"
+}
+
+.fa-hire-a-helper:before {
+	content: "\F3B0"
+}
+
+.fa-history:before {
+	content: "\F1DA"
+}
+
+.fa-hockey-puck:before {
+	content: "\F453"
+}
+
+.fa-home:before {
+	content: "\F015"
+}
+
+.fa-hooli:before {
+	content: "\F427"
+}
+
+.fa-hospital:before {
+	content: "\F0F8"
+}
+
+.fa-hotjar:before {
+	content: "\F3B1"
+}
+
+.fa-hourglass:before {
+	content: "\F254"
+}
+
+.fa-hourglass-end:before {
+	content: "\F253"
+}
+
+.fa-hourglass-half:before {
+	content: "\F252"
+}
+
+.fa-hourglass-start:before {
+	content: "\F251"
+}
+
+.fa-houzz:before {
+	content: "\F27C"
+}
+
+.fa-html5:before {
+	content: "\F13B"
+}
+
+.fa-hubspot:before {
+	content: "\F3B2"
+}
+
+.fa-i-cursor:before {
+	content: "\F246"
+}
+
+.fa-id-badge:before {
+	content: "\F2C1"
+}
+
+.fa-id-card:before {
+	content: "\F2C2"
+}
+
+.fa-image:before {
+	content: "\F03E"
+}
+
+.fa-images:before {
+	content: "\F302"
+}
+
+.fa-imdb:before {
+	content: "\F2D8"
+}
+
+.fa-inbox:before {
+	content: "\F01C"
+}
+
+.fa-indent:before {
+	content: "\F03C"
+}
+
+.fa-industry:before {
+	content: "\F275"
+}
+
+.fa-info:before {
+	content: "\F129"
+}
+
+.fa-info-circle:before {
+	content: "\F05A"
+}
+
+.fa-instagram:before {
+	content: "\F16D"
+}
+
+.fa-internet-explorer:before {
+	content: "\F26B"
+}
+
+.fa-ioxhost:before {
+	content: "\F208"
+}
+
+.fa-italic:before {
+	content: "\F033"
+}
+
+.fa-itunes:before {
+	content: "\F3B4"
+}
+
+.fa-itunes-note:before {
+	content: "\F3B5"
+}
+
+.fa-jenkins:before {
+	content: "\F3B6"
+}
+
+.fa-joget:before {
+	content: "\F3B7"
+}
+
+.fa-joomla:before {
+	content: "\F1AA"
+}
+
+.fa-js:before {
+	content: "\F3B8"
+}
+
+.fa-js-square:before {
+	content: "\F3B9"
+}
+
+.fa-jsfiddle:before {
+	content: "\F1CC"
+}
+
+.fa-key:before {
+	content: "\F084"
+}
+
+.fa-keyboard:before {
+	content: "\F11C"
+}
+
+.fa-keycdn:before {
+	content: "\F3BA"
+}
+
+.fa-kickstarter:before {
+	content: "\F3BB"
+}
+
+.fa-kickstarter-k:before {
+	content: "\F3BC"
+}
+
+.fa-korvue:before {
+	content: "\F42F"
+}
+
+.fa-language:before {
+	content: "\F1AB"
+}
+
+.fa-laptop:before {
+	content: "\F109"
+}
+
+.fa-laravel:before {
+	content: "\F3BD"
+}
+
+.fa-lastfm:before {
+	content: "\F202"
+}
+
+.fa-lastfm-square:before {
+	content: "\F203"
+}
+
+.fa-leaf:before {
+	content: "\F06C"
+}
+
+.fa-leanpub:before {
+	content: "\F212"
+}
+
+.fa-lemon:before {
+	content: "\F094"
+}
+
+.fa-less:before {
+	content: "\F41D"
+}
+
+.fa-level-down-alt:before {
+	content: "\F3BE"
+}
+
+.fa-level-up-alt:before {
+	content: "\F3BF"
+}
+
+.fa-life-ring:before {
+	content: "\F1CD"
+}
+
+.fa-lightbulb:before {
+	content: "\F0EB"
+}
+
+.fa-line:before {
+	content: "\F3C0"
+}
+
+.fa-link:before {
+	content: "\F0C1"
+}
+
+.fa-linkedin:before {
+	content: "\F08C"
+}
+
+.fa-linkedin-in:before {
+	content: "\F0E1"
+}
+
+.fa-linode:before {
+	content: "\F2B8"
+}
+
+.fa-linux:before {
+	content: "\F17C"
+}
+
+.fa-lira-sign:before {
+	content: "\F195"
+}
+
+.fa-list:before {
+	content: "\F03A"
+}
+
+.fa-list-alt:before {
+	content: "\F022"
+}
+
+.fa-list-ol:before {
+	content: "\F0CB"
+}
+
+.fa-list-ul:before {
+	content: "\F0CA"
+}
+
+.fa-location-arrow:before {
+	content: "\F124"
+}
+
+.fa-lock:before {
+	content: "\F023"
+}
+
+.fa-lock-open:before {
+	content: "\F3C1"
+}
+
+.fa-long-arrow-alt-down:before {
+	content: "\F309"
+}
+
+.fa-long-arrow-alt-left:before {
+	content: "\F30A"
+}
+
+.fa-long-arrow-alt-right:before {
+	content: "\F30B"
+}
+
+.fa-long-arrow-alt-up:before {
+	content: "\F30C"
+}
+
+.fa-low-vision:before {
+	content: "\F2A8"
+}
+
+.fa-lyft:before {
+	content: "\F3C3"
+}
+
+.fa-magento:before {
+	content: "\F3C4"
+}
+
+.fa-magic:before {
+	content: "\F0D0"
+}
+
+.fa-magnet:before {
+	content: "\F076"
+}
+
+.fa-male:before {
+	content: "\F183"
+}
+
+.fa-map:before {
+	content: "\F279"
+}
+
+.fa-map-marker:before {
+	content: "\F041"
+}
+
+.fa-map-marker-alt:before {
+	content: "\F3C5"
+}
+
+.fa-map-pin:before {
+	content: "\F276"
+}
+
+.fa-map-signs:before {
+	content: "\F277"
+}
+
+.fa-mars:before {
+	content: "\F222"
+}
+
+.fa-mars-double:before {
+	content: "\F227"
+}
+
+.fa-mars-stroke:before {
+	content: "\F229"
+}
+
+.fa-mars-stroke-h:before {
+	content: "\F22B"
+}
+
+.fa-mars-stroke-v:before {
+	content: "\F22A"
+}
+
+.fa-maxcdn:before {
+	content: "\F136"
+}
+
+.fa-medapps:before {
+	content: "\F3C6"
+}
+
+.fa-medium:before {
+	content: "\F23A"
+}
+
+.fa-medium-m:before {
+	content: "\F3C7"
+}
+
+.fa-medkit:before {
+	content: "\F0FA"
+}
+
+.fa-medrt:before {
+	content: "\F3C8"
+}
+
+.fa-meetup:before {
+	content: "\F2E0"
+}
+
+.fa-meh:before {
+	content: "\F11A"
+}
+
+.fa-mercury:before {
+	content: "\F223"
+}
+
+.fa-microchip:before {
+	content: "\F2DB"
+}
+
+.fa-microphone:before {
+	content: "\F130"
+}
+
+.fa-microphone-slash:before {
+	content: "\F131"
+}
+
+.fa-microsoft:before {
+	content: "\F3CA"
+}
+
+.fa-minus:before {
+	content: "\F068"
+}
+
+.fa-minus-circle:before {
+	content: "\F056"
+}
+
+.fa-minus-square:before {
+	content: "\F146"
+}
+
+.fa-mix:before {
+	content: "\F3CB"
+}
+
+.fa-mixcloud:before {
+	content: "\F289"
+}
+
+.fa-mizuni:before {
+	content: "\F3CC"
+}
+
+.fa-mobile:before {
+	content: "\F10B"
+}
+
+.fa-mobile-alt:before {
+	content: "\F3CD"
+}
+
+.fa-modx:before {
+	content: "\F285"
+}
+
+.fa-monero:before {
+	content: "\F3D0"
+}
+
+.fa-money-bill-alt:before {
+	content: "\F3D1"
+}
+
+.fa-moon:before {
+	content: "\F186"
+}
+
+.fa-motorcycle:before {
+	content: "\F21C"
+}
+
+.fa-mouse-pointer:before {
+	content: "\F245"
+}
+
+.fa-music:before {
+	content: "\F001"
+}
+
+.fa-napster:before {
+	content: "\F3D2"
+}
+
+.fa-neuter:before {
+	content: "\F22C"
+}
+
+.fa-newspaper:before {
+	content: "\F1EA"
+}
+
+.fa-nintendo-switch:before {
+	content: "\F418"
+}
+
+.fa-node:before {
+	content: "\F419"
+}
+
+.fa-node-js:before {
+	content: "\F3D3"
+}
+
+.fa-npm:before {
+	content: "\F3D4"
+}
+
+.fa-ns8:before {
+	content: "\F3D5"
+}
+
+.fa-nutritionix:before {
+	content: "\F3D6"
+}
+
+.fa-object-group:before {
+	content: "\F247"
+}
+
+.fa-object-ungroup:before {
+	content: "\F248"
+}
+
+.fa-odnoklassniki:before {
+	content: "\F263"
+}
+
+.fa-odnoklassniki-square:before {
+	content: "\F264"
+}
+
+.fa-opencart:before {
+	content: "\F23D"
+}
+
+.fa-openid:before {
+	content: "\F19B"
+}
+
+.fa-opera:before {
+	content: "\F26A"
+}
+
+.fa-optin-monster:before {
+	content: "\F23C"
+}
+
+.fa-osi:before {
+	content: "\F41A"
+}
+
+.fa-outdent:before {
+	content: "\F03B"
+}
+
+.fa-page4:before {
+	content: "\F3D7"
+}
+
+.fa-pagelines:before {
+	content: "\F18C"
+}
+
+.fa-paint-brush:before {
+	content: "\F1FC"
+}
+
+.fa-palfed:before {
+	content: "\F3D8"
+}
+
+.fa-paper-plane:before {
+	content: "\F1D8"
+}
+
+.fa-paperclip:before {
+	content: "\F0C6"
+}
+
+.fa-paragraph:before {
+	content: "\F1DD"
+}
+
+.fa-paste:before {
+	content: "\F0EA"
+}
+
+.fa-patreon:before {
+	content: "\F3D9"
+}
+
+.fa-pause:before {
+	content: "\F04C"
+}
+
+.fa-pause-circle:before {
+	content: "\F28B"
+}
+
+.fa-paw:before {
+	content: "\F1B0"
+}
+
+.fa-paypal:before {
+	content: "\F1ED"
+}
+
+.fa-pen-square:before {
+	content: "\F14B"
+}
+
+.fa-pencil-alt:before {
+	content: "\F303"
+}
+
+.fa-percent:before {
+	content: "\F295"
+}
+
+.fa-periscope:before {
+	content: "\F3DA"
+}
+
+.fa-phabricator:before {
+	content: "\F3DB"
+}
+
+.fa-phoenix-framework:before {
+	content: "\F3DC"
+}
+
+.fa-phone:before {
+	content: "\F095"
+}
+
+.fa-phone-square:before {
+	content: "\F098"
+}
+
+.fa-phone-volume:before {
+	content: "\F2A0"
+}
+
+.fa-php:before {
+	content: "\F457"
+}
+
+.fa-pied-piper:before {
+	content: "\F2AE"
+}
+
+.fa-pied-piper-alt:before {
+	content: "\F1A8"
+}
+
+.fa-pied-piper-pp:before {
+	content: "\F1A7"
+}
+
+.fa-pinterest:before {
+	content: "\F0D2"
+}
+
+.fa-pinterest-p:before {
+	content: "\F231"
+}
+
+.fa-pinterest-square:before {
+	content: "\F0D3"
+}
+
+.fa-plane:before {
+	content: "\F072"
+}
+
+.fa-play:before {
+	content: "\F04B"
+}
+
+.fa-play-circle:before {
+	content: "\F144"
+}
+
+.fa-playstation:before {
+	content: "\F3DF"
+}
+
+.fa-plug:before {
+	content: "\F1E6"
+}
+
+.fa-plus:before {
+	content: "\F067"
+}
+
+.fa-plus-circle:before {
+	content: "\F055"
+}
+
+.fa-plus-square:before {
+	content: "\F0FE"
+}
+
+.fa-podcast:before {
+	content: "\F2CE"
+}
+
+.fa-pound-sign:before {
+	content: "\F154"
+}
+
+.fa-power-off:before {
+	content: "\F011"
+}
+
+.fa-print:before {
+	content: "\F02F"
+}
+
+.fa-product-hunt:before {
+	content: "\F288"
+}
+
+.fa-pushed:before {
+	content: "\F3E1"
+}
+
+.fa-puzzle-piece:before {
+	content: "\F12E"
+}
+
+.fa-python:before {
+	content: "\F3E2"
+}
+
+.fa-qq:before {
+	content: "\F1D6"
+}
+
+.fa-qrcode:before {
+	content: "\F029"
+}
+
+.fa-question:before {
+	content: "\F128"
+}
+
+.fa-question-circle:before {
+	content: "\F059"
+}
+
+.fa-quidditch:before {
+	content: "\F458"
+}
+
+.fa-quinscape:before {
+	content: "\F459"
+}
+
+.fa-quora:before {
+	content: "\F2C4"
+}
+
+.fa-quote-left:before {
+	content: "\F10D"
+}
+
+.fa-quote-right:before {
+	content: "\F10E"
+}
+
+.fa-random:before {
+	content: "\F074"
+}
+
+.fa-ravelry:before {
+	content: "\F2D9"
+}
+
+.fa-react:before {
+	content: "\F41B"
+}
+
+.fa-rebel:before {
+	content: "\F1D0"
+}
+
+.fa-recycle:before {
+	content: "\F1B8"
+}
+
+.fa-red-river:before {
+	content: "\F3E3"
+}
+
+.fa-reddit:before {
+	content: "\F1A1"
+}
+
+.fa-reddit-alien:before {
+	content: "\F281"
+}
+
+.fa-reddit-square:before {
+	content: "\F1A2"
+}
+
+.fa-redo:before {
+	content: "\F01E"
+}
+
+.fa-redo-alt:before {
+	content: "\F2F9"
+}
+
+.fa-registered:before {
+	content: "\F25D"
+}
+
+.fa-rendact:before {
+	content: "\F3E4"
+}
+
+.fa-renren:before {
+	content: "\F18B"
+}
+
+.fa-reply:before {
+	content: "\F3E5"
+}
+
+.fa-reply-all:before {
+	content: "\F122"
+}
+
+.fa-replyd:before {
+	content: "\F3E6"
+}
+
+.fa-resolving:before {
+	content: "\F3E7"
+}
+
+.fa-retweet:before {
+	content: "\F079"
+}
+
+.fa-road:before {
+	content: "\F018"
+}
+
+.fa-rocket:before {
+	content: "\F135"
+}
+
+.fa-rocketchat:before {
+	content: "\F3E8"
+}
+
+.fa-rockrms:before {
+	content: "\F3E9"
+}
+
+.fa-rss:before {
+	content: "\F09E"
+}
+
+.fa-rss-square:before {
+	content: "\F143"
+}
+
+.fa-ruble-sign:before {
+	content: "\F158"
+}
+
+.fa-rupee-sign:before {
+	content: "\F156"
+}
+
+.fa-safari:before {
+	content: "\F267"
+}
+
+.fa-sass:before {
+	content: "\F41E"
+}
+
+.fa-save:before {
+	content: "\F0C7"
+}
+
+.fa-schlix:before {
+	content: "\F3EA"
+}
+
+.fa-scribd:before {
+	content: "\F28A"
+}
+
+.fa-search:before {
+	content: "\F002"
+}
+
+.fa-search-minus:before {
+	content: "\F010"
+}
+
+.fa-search-plus:before {
+	content: "\F00E"
+}
+
+.fa-searchengin:before {
+	content: "\F3EB"
+}
+
+.fa-sellcast:before {
+	content: "\F2DA"
+}
+
+.fa-sellsy:before {
+	content: "\F213"
+}
+
+.fa-server:before {
+	content: "\F233"
+}
+
+.fa-servicestack:before {
+	content: "\F3EC"
+}
+
+.fa-share:before {
+	content: "\F064"
+}
+
+.fa-share-alt:before {
+	content: "\F1E0"
+}
+
+.fa-share-alt-square:before {
+	content: "\F1E1"
+}
+
+.fa-share-square:before {
+	content: "\F14D"
+}
+
+.fa-shekel-sign:before {
+	content: "\F20B"
+}
+
+.fa-shield-alt:before {
+	content: "\F3ED"
+}
+
+.fa-ship:before {
+	content: "\F21A"
+}
+
+.fa-shirtsinbulk:before {
+	content: "\F214"
+}
+
+.fa-shopping-bag:before {
+	content: "\F290"
+}
+
+.fa-shopping-basket:before {
+	content: "\F291"
+}
+
+.fa-shopping-cart:before {
+	content: "\F07A"
+}
+
+.fa-shower:before {
+	content: "\F2CC"
+}
+
+.fa-sign-in-alt:before {
+	content: "\F2F6"
+}
+
+.fa-sign-language:before {
+	content: "\F2A7"
+}
+
+.fa-sign-out-alt:before {
+	content: "\F2F5"
+}
+
+.fa-signal:before {
+	content: "\F012"
+}
+
+.fa-simplybuilt:before {
+	content: "\F215"
+}
+
+.fa-sistrix:before {
+	content: "\F3EE"
+}
+
+.fa-sitemap:before {
+	content: "\F0E8"
+}
+
+.fa-skyatlas:before {
+	content: "\F216"
+}
+
+.fa-skype:before {
+	content: "\F17E"
+}
+
+.fa-slack:before {
+	content: "\F198"
+}
+
+.fa-slack-hash:before {
+	content: "\F3EF"
+}
+
+.fa-sliders-h:before {
+	content: "\F1DE"
+}
+
+.fa-slideshare:before {
+	content: "\F1E7"
+}
+
+.fa-smile:before {
+	content: "\F118"
+}
+
+.fa-snapchat:before {
+	content: "\F2AB"
+}
+
+.fa-snapchat-ghost:before {
+	content: "\F2AC"
+}
+
+.fa-snapchat-square:before {
+	content: "\F2AD"
+}
+
+.fa-snowflake:before {
+	content: "\F2DC"
+}
+
+.fa-sort:before {
+	content: "\F0DC"
+}
+
+.fa-sort-alpha-down:before {
+	content: "\F15D"
+}
+
+.fa-sort-alpha-up:before {
+	content: "\F15E"
+}
+
+.fa-sort-amount-down:before {
+	content: "\F160"
+}
+
+.fa-sort-amount-up:before {
+	content: "\F161"
+}
+
+.fa-sort-down:before {
+	content: "\F0DD"
+}
+
+.fa-sort-numeric-down:before {
+	content: "\F162"
+}
+
+.fa-sort-numeric-up:before {
+	content: "\F163"
+}
+
+.fa-sort-up:before {
+	content: "\F0DE"
+}
+
+.fa-soundcloud:before {
+	content: "\F1BE"
+}
+
+.fa-space-shuttle:before {
+	content: "\F197"
+}
+
+.fa-speakap:before {
+	content: "\F3F3"
+}
+
+.fa-spinner:before {
+	content: "\F110"
+}
+
+.fa-spotify:before {
+	content: "\F1BC"
+}
+
+.fa-square:before {
+	content: "\F0C8"
+}
+
+.fa-square-full:before {
+	content: "\F45C"
+}
+
+.fa-stack-exchange:before {
+	content: "\F18D"
+}
+
+.fa-stack-overflow:before {
+	content: "\F16C"
+}
+
+.fa-star:before {
+	content: "\F005"
+}
+
+.fa-star-half:before {
+	content: "\F089"
+}
+
+.fa-staylinked:before {
+	content: "\F3F5"
+}
+
+.fa-steam:before {
+	content: "\F1B6"
+}
+
+.fa-steam-square:before {
+	content: "\F1B7"
+}
+
+.fa-steam-symbol:before {
+	content: "\F3F6"
+}
+
+.fa-step-backward:before {
+	content: "\F048"
+}
+
+.fa-step-forward:before {
+	content: "\F051"
+}
+
+.fa-stethoscope:before {
+	content: "\F0F1"
+}
+
+.fa-sticker-mule:before {
+	content: "\F3F7"
+}
+
+.fa-sticky-note:before {
+	content: "\F249"
+}
+
+.fa-stop:before {
+	content: "\F04D"
+}
+
+.fa-stop-circle:before {
+	content: "\F28D"
+}
+
+.fa-stopwatch:before {
+	content: "\F2F2"
+}
+
+.fa-strava:before {
+	content: "\F428"
+}
+
+.fa-street-view:before {
+	content: "\F21D"
+}
+
+.fa-strikethrough:before {
+	content: "\F0CC"
+}
+
+.fa-stripe:before {
+	content: "\F429"
+}
+
+.fa-stripe-s:before {
+	content: "\F42A"
+}
+
+.fa-studiovinari:before {
+	content: "\F3F8"
+}
+
+.fa-stumbleupon:before {
+	content: "\F1A4"
+}
+
+.fa-stumbleupon-circle:before {
+	content: "\F1A3"
+}
+
+.fa-subscript:before {
+	content: "\F12C"
+}
+
+.fa-subway:before {
+	content: "\F239"
+}
+
+.fa-suitcase:before {
+	content: "\F0F2"
+}
+
+.fa-sun:before {
+	content: "\F185"
+}
+
+.fa-superpowers:before {
+	content: "\F2DD"
+}
+
+.fa-superscript:before {
+	content: "\F12B"
+}
+
+.fa-supple:before {
+	content: "\F3F9"
+}
+
+.fa-sync:before {
+	content: "\F021"
+}
+
+.fa-sync-alt:before {
+	content: "\F2F1"
+}
+
+.fa-table:before {
+	content: "\F0CE"
+}
+
+.fa-table-tennis:before {
+	content: "\F45D"
+}
+
+.fa-tablet:before {
+	content: "\F10A"
+}
+
+.fa-tablet-alt:before {
+	content: "\F3FA"
+}
+
+.fa-tachometer-alt:before {
+	content: "\F3FD"
+}
+
+.fa-tag:before {
+	content: "\F02B"
+}
+
+.fa-tags:before {
+	content: "\F02C"
+}
+
+.fa-tasks:before {
+	content: "\F0AE"
+}
+
+.fa-taxi:before {
+	content: "\F1BA"
+}
+
+.fa-telegram:before {
+	content: "\F2C6"
+}
+
+.fa-telegram-plane:before {
+	content: "\F3FE"
+}
+
+.fa-tencent-weibo:before {
+	content: "\F1D5"
+}
+
+.fa-terminal:before {
+	content: "\F120"
+}
+
+.fa-text-height:before {
+	content: "\F034"
+}
+
+.fa-text-width:before {
+	content: "\F035"
+}
+
+.fa-th:before {
+	content: "\F00A"
+}
+
+.fa-th-large:before {
+	content: "\F009"
+}
+
+.fa-th-list:before {
+	content: "\F00B"
+}
+
+.fa-themeisle:before {
+	content: "\F2B2"
+}
+
+.fa-thermometer-empty:before {
+	content: "\F2CB"
+}
+
+.fa-thermometer-full:before {
+	content: "\F2C7"
+}
+
+.fa-thermometer-half:before {
+	content: "\F2C9"
+}
+
+.fa-thermometer-quarter:before {
+	content: "\F2CA"
+}
+
+.fa-thermometer-three-quarters:before {
+	content: "\F2C8"
+}
+
+.fa-thumbs-down:before {
+	content: "\F165"
+}
+
+.fa-thumbs-up:before {
+	content: "\F164"
+}
+
+.fa-thumbtack:before {
+	content: "\F08D"
+}
+
+.fa-ticket-alt:before {
+	content: "\F3FF"
+}
+
+.fa-times:before {
+	content: "\F00D"
+}
+
+.fa-times-circle:before {
+	content: "\F057"
+}
+
+.fa-tint:before {
+	content: "\F043"
+}
+
+.fa-toggle-off:before {
+	content: "\F204"
+}
+
+.fa-toggle-on:before {
+	content: "\F205"
+}
+
+.fa-trademark:before {
+	content: "\F25C"
+}
+
+.fa-train:before {
+	content: "\F238"
+}
+
+.fa-transgender:before {
+	content: "\F224"
+}
+
+.fa-transgender-alt:before {
+	content: "\F225"
+}
+
+.fa-trash:before {
+	content: "\F1F8"
+}
+
+.fa-trash-alt:before {
+	content: "\F2ED"
+}
+
+.fa-tree:before {
+	content: "\F1BB"
+}
+
+.fa-trello:before {
+	content: "\F181"
+}
+
+.fa-tripadvisor:before {
+	content: "\F262"
+}
+
+.fa-trophy:before {
+	content: "\F091"
+}
+
+.fa-truck:before {
+	content: "\F0D1"
+}
+
+.fa-tty:before {
+	content: "\F1E4"
+}
+
+.fa-tumblr:before {
+	content: "\F173"
+}
+
+.fa-tumblr-square:before {
+	content: "\F174"
+}
+
+.fa-tv:before {
+	content: "\F26C"
+}
+
+.fa-twitch:before {
+	content: "\F1E8"
+}
+
+.fa-twitter:before {
+	content: "\F099"
+}
+
+.fa-twitter-square:before {
+	content: "\F081"
+}
+
+.fa-typo3:before {
+	content: "\F42B"
+}
+
+.fa-uber:before {
+	content: "\F402"
+}
+
+.fa-uikit:before {
+	content: "\F403"
+}
+
+.fa-umbrella:before {
+	content: "\F0E9"
+}
+
+.fa-underline:before {
+	content: "\F0CD"
+}
+
+.fa-undo:before {
+	content: "\F0E2"
+}
+
+.fa-undo-alt:before {
+	content: "\F2EA"
+}
+
+.fa-uniregistry:before {
+	content: "\F404"
+}
+
+.fa-universal-access:before {
+	content: "\F29A"
+}
+
+.fa-university:before {
+	content: "\F19C"
+}
+
+.fa-unlink:before {
+	content: "\F127"
+}
+
+.fa-unlock:before {
+	content: "\F09C"
+}
+
+.fa-unlock-alt:before {
+	content: "\F13E"
+}
+
+.fa-untappd:before {
+	content: "\F405"
+}
+
+.fa-upload:before {
+	content: "\F093"
+}
+
+.fa-usb:before {
+	content: "\F287"
+}
+
+.fa-user:before {
+	content: "\F007"
+}
+
+.fa-user-circle:before {
+	content: "\F2BD"
+}
+
+.fa-user-md:before {
+	content: "\F0F0"
+}
+
+.fa-user-plus:before {
+	content: "\F234"
+}
+
+.fa-user-secret:before {
+	content: "\F21B"
+}
+
+.fa-user-times:before {
+	content: "\F235"
+}
+
+.fa-users:before {
+	content: "\F0C0"
+}
+
+.fa-ussunnah:before {
+	content: "\F407"
+}
+
+.fa-utensil-spoon:before {
+	content: "\F2E5"
+}
+
+.fa-utensils:before {
+	content: "\F2E7"
+}
+
+.fa-vaadin:before {
+	content: "\F408"
+}
+
+.fa-venus:before {
+	content: "\F221"
+}
+
+.fa-venus-double:before {
+	content: "\F226"
+}
+
+.fa-venus-mars:before {
+	content: "\F228"
+}
+
+.fa-viacoin:before {
+	content: "\F237"
+}
+
+.fa-viadeo:before {
+	content: "\F2A9"
+}
+
+.fa-viadeo-square:before {
+	content: "\F2AA"
+}
+
+.fa-viber:before {
+	content: "\F409"
+}
+
+.fa-video:before {
+	content: "\F03D"
+}
+
+.fa-vimeo:before {
+	content: "\F40A"
+}
+
+.fa-vimeo-square:before {
+	content: "\F194"
+}
+
+.fa-vimeo-v:before {
+	content: "\F27D"
+}
+
+.fa-vine:before {
+	content: "\F1CA"
+}
+
+.fa-vk:before {
+	content: "\F189"
+}
+
+.fa-vnv:before {
+	content: "\F40B"
+}
+
+.fa-volleyball-ball:before {
+	content: "\F45F"
+}
+
+.fa-volume-down:before {
+	content: "\F027"
+}
+
+.fa-volume-off:before {
+	content: "\F026"
+}
+
+.fa-volume-up:before {
+	content: "\F028"
+}
+
+.fa-vuejs:before {
+	content: "\F41F"
+}
+
+.fa-weibo:before {
+	content: "\F18A"
+}
+
+.fa-weixin:before {
+	content: "\F1D7"
+}
+
+.fa-whatsapp:before {
+	content: "\F232"
+}
+
+.fa-whatsapp-square:before {
+	content: "\F40C"
+}
+
+.fa-wheelchair:before {
+	content: "\F193"
+}
+
+.fa-whmcs:before {
+	content: "\F40D"
+}
+
+.fa-wifi:before {
+	content: "\F1EB"
+}
+
+.fa-wikipedia-w:before {
+	content: "\F266"
+}
+
+.fa-window-close:before {
+	content: "\F410"
+}
+
+.fa-window-maximize:before {
+	content: "\F2D0"
+}
+
+.fa-window-minimize:before {
+	content: "\F2D1"
+}
+
+.fa-window-restore:before {
+	content: "\F2D2"
+}
+
+.fa-windows:before {
+	content: "\F17A"
+}
+
+.fa-won-sign:before {
+	content: "\F159"
+}
+
+.fa-wordpress:before {
+	content: "\F19A"
+}
+
+.fa-wordpress-simple:before {
+	content: "\F411"
+}
+
+.fa-wpbeginner:before {
+	content: "\F297"
+}
+
+.fa-wpexplorer:before {
+	content: "\F2DE"
+}
+
+.fa-wpforms:before {
+	content: "\F298"
+}
+
+.fa-wrench:before {
+	content: "\F0AD"
+}
+
+.fa-xbox:before {
+	content: "\F412"
+}
+
+.fa-xing:before {
+	content: "\F168"
+}
+
+.fa-xing-square:before {
+	content: "\F169"
+}
+
+.fa-y-combinator:before {
+	content: "\F23B"
+}
+
+.fa-yahoo:before {
+	content: "\F19E"
+}
+
+.fa-yandex:before {
+	content: "\F413"
+}
+
+.fa-yandex-international:before {
+	content: "\F414"
+}
+
+.fa-yelp:before {
+	content: "\F1E9"
+}
+
+.fa-yen-sign:before {
+	content: "\F157"
+}
+
+.fa-yoast:before {
+	content: "\F2B1"
+}
+
+.fa-youtube:before {
+	content: "\F167"
+}
+
+.fa-youtube-square:before {
+	content: "\F431"
+}
+
+.sr-only {
+	border: 0;
+	clip: rect(0, 0, 0, 0);
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+	padding: 0;
+	position: absolute;
+	width: 1px
+}
+
+.sr-only-focusable:active,
+.sr-only-focusable:focus {
+	clip: auto;
+	height: auto;
+	margin: 0;
+	overflow: visible;
+	position: static;
+	width: auto
+}
+
+@font-face {
+	font-family: Font Awesome\ 5 Brands;
+	font-style: normal;
+	font-weight: 400;
+	src: url(fa-brands-400.eot);
+	src: url(fa-brands-400.eot?#iefix) format("embedded-opentype"), url(fa-brands-400.woff2) format("woff2"), url(fa-brands-400.woff) format("woff"), url(fa-brands-400.ttf) format("truetype"), url(fa-brands-400.svg#fontawesome) format("svg")
+}
+
+.fab {
+	font-family: Font Awesome\ 5 Brands
+}
+
+@font-face {
+	font-family: Font Awesome\ 5 Free;
+	font-style: normal;
+	font-weight: 400;
+	src: url(fa-regular-400.eot);
+	src: url(fa-regular-400.eot?#iefix) format("embedded-opentype"), url(fa-regular-400.woff2) format("woff2"), url(fa-regular-400.woff) format("woff"), url(fa-regular-400.ttf) format("truetype"), url(fa-regular-400.svg#fontawesome) format("svg")
+}
+
+.far {
+	font-weight: 400
+}
+
+@font-face {
+	font-family: Font Awesome\ 5 Free;
+	font-style: normal;
+	font-weight: 900;
+	src: url(fa-solid-900.eot);
+	src: url(fa-solid-900.eot?#iefix) format("embedded-opentype"), url(fa-solid-900.woff2) format("woff2"), url(fa-solid-900.woff) format("woff"), url(fa-solid-900.ttf) format("truetype"), url(fa-solid-900.svg#fontawesome) format("svg")
+}
+
+.fa,
+.far,
+.fas {
+
+}
+
+.fa,
+.fas {
+	font-weight: 900
+}
+
+.shariff:after,
+.shariff:before {
+	content: " ";
+	display: table
+}
+
+.shariff:after {
+	clear: both
+}
+
+.shariff ul {
+	padding: 0;
+	margin: 0;
+	list-style: none
+}
+
+.shariff li {
+	overflow: hidden
+}
+
+.shariff li,
+.shariff li a {
+	height: 35px;
+	-webkit-box-sizing: border-box;
+	box-sizing: border-box
+}
+
+.shariff li a {
+	color: #fff;
+	position: relative;
+	display: block;
+	text-decoration: none
+}
+
+.shariff li .share_count,
+.shariff li .share_text {
+	font-family: Arial, Helvetica, sans-serif;
+	font-size: 12px;
+	vertical-align: middle;
+	line-height: 35px
+}
+
+.shariff li .fab,
+.shariff li .far,
+.shariff li .fas {
+	width: 35px;
+	line-height: 35px;
+	text-align: center;
+	vertical-align: middle
+}
+
+.shariff li .share_count {
+	padding: 0 8px;
+	height: 33px;
+	position: absolute;
+	top: 1px;
+	right: 1px
+}
+
+.shariff .orientation-horizontal li {
+	-webkit-box-flex: 1
+}
+
+.shariff .orientation-horizontal .info {
+	-webkit-box-flex: 0
+}
+
+.shariff .orientation-horizontal {
+	display: -webkit-box;
+	display: -ms-flexbox;
+	display: flex;
+	-ms-flex-wrap: wrap;
+	flex-wrap: wrap
+}
+
+.shariff .orientation-horizontal li {
+	float: left;
+	-webkit-box-flex: 0;
+	-ms-flex: none;
+	flex: none;
+	width: 35px;
+	margin-right: 3%;
+	margin-bottom: 10px
+}
+
+.shariff .orientation-horizontal li:last-child {
+	margin-right: 0
+}
+
+.shariff .orientation-horizontal li .share_text {
+	display: block;
+	text-indent: -9999px;
+	padding-left: 3px
+}
+
+.shariff .orientation-horizontal li .share_count {
+	display: none
+}
+
+.shariff .theme-grey .shariff-button a {
+	background-color: #b0b0b0
+}
+
+.shariff .theme-grey .shariff-button .share_count {
+	background-color: #ccc;
+	color: #333
+}
+
+.shariff .theme-white .shariff-button {
+	border: 1px solid #ddd
+}
+
+.shariff .theme-white .shariff-button a {
+	background-color: #fff
+}
+
+.shariff .theme-white .shariff-button a:hover {
+	background-color: #eee
+}
+
+.shariff .theme-white .shariff-button .share_count {
+	background-color: #fff;
+	color: #999
+}
+
+.shariff .orientation-vertical.button-style-icon {
+	min-width: 35px
+}
+
+.shariff .orientation-vertical.button-style-icon-count {
+	min-width: 80px
+}
+
+.shariff .orientation-vertical.button-style-standard {
+	min-width: 110px
+}
+
+.shariff .orientation-vertical li {
+	display: block;
+	width: 100%;
+	margin: 5px 0
+}
+
+.shariff .orientation-vertical.button-style-icon-count li .share_count,
+.shariff .orientation-vertical.button-style-standard li .share_count {
+	width: 24px;
+	text-align: right
+}
+
+@media only screen and (min-width:360px) {
+	.shariff .orientation-horizontal li {
+		margin-right: 1.8%
+	}
+	.shariff .orientation-horizontal.button-style-icon-count li,
+	.shariff .orientation-horizontal.button-style-standard li {
+		min-width: 80px
+	}
+	.shariff .orientation-horizontal.button-style-icon-count li .share_count,
+	.shariff .orientation-horizontal.button-style-standard li .share_count {
+		display: block
+	}
+	.shariff .orientation-horizontal.button-style-standard li {
+		width: auto;
+		-webkit-box-flex: 1;
+		-ms-flex: 1 0 auto;
+		flex: 1 0 auto
+	}
+	.shariff .orientation-horizontal.button-style-standard.shariff-col-1 li,
+	.shariff .orientation-horizontal.button-style-standard.shariff-col-2 li {
+		min-width: 110px;
+		max-width: 160px
+	}
+	.shariff .orientation-horizontal.button-style-standard.shariff-col-1 li .share_text,
+	.shariff .orientation-horizontal.button-style-standard.shariff-col-2 li .share_text {
+		text-indent: 0;
+		display: inline
+	}
+	.shariff .orientation-horizontal.button-style-standard.shariff-col-5 li,
+	.shariff .orientation-horizontal.button-style-standard.shariff-col-6 li {
+		-webkit-box-flex: 0;
+		-ms-flex: none;
+		flex: none
+	}
+}
+
+@media only screen and (min-width:640px) {
+	.shariff .orientation-horizontal.button-style-standard.shariff-col-3 li {
+		min-width: 110px;
+		max-width: 160px
+	}
+	.shariff .orientation-horizontal.button-style-standard.shariff-col-3 li .share_text {
+		text-indent: 0;
+		display: inline
+	}
+}
+
+@media only screen and (min-width:768px) {
+	.shariff .orientation-horizontal.button-style-standard li {
+		min-width: 110px;
+		max-width: 160px
+	}
+	.shariff .orientation-horizontal.button-style-standard li .share_text {
+		text-indent: 0;
+		display: inline
+	}
+	.shariff .orientation-horizontal.button-style-standard.shariff-col-5 li,
+	.shariff .orientation-horizontal.button-style-standard.shariff-col-6 li {
+		-webkit-box-flex: 1;
+		-ms-flex: 1 0 auto;
+		flex: 1 0 auto
+	}
+}
+
+@media only screen and (min-width:1024px) {
+	.shariff li,
+	.shariff li a {
+		height: 30px
+	}
+	.shariff li .fab,
+	.shariff li .far,
+	.shariff li .fas {
+		width: 30px;
+		line-height: 30px
+	}
+	.shariff li .share_count,
+	.shariff li .share_text {
+		line-height: 30px
+	}
+	.shariff li .share_count {
+		height: 28px
+	}
+}
+
+.shariff .addthis a {
+	background-color: #f8694d
+}
+
+.shariff .addthis a:hover {
+	background-color: #f75b44
+}
+
+.shariff .addthis .fa-plus {
+	font-size: 14px
+}
+
+.shariff .addthis .share_count {
+	color: #f8694d;
+	background-color: #f1b8b0
+}
+
+.shariff .theme-white .addthis a {
+	color: #f8694d
+}
+
+@media only screen and (min-width:600px) {
+	.shariff .addthis .fa-plus {
+		font-size: 14px;
+		position: relative;
+		top: 1px
+	}
+}
+
+.shariff .diaspora a {
+	background-color: #999
+}
+
+.shariff .diaspora a:hover {
+	background-color: #b3b3b3
+}
+
+.shariff .diaspora .fa-times-circle {
+	font-size: 17px
+}
+
+.shariff .theme-white .diaspora a {
+	color: #999
+}
+
+@media only screen and (min-width:600px) {
+	.shariff .diaspora .fa-times-circle {
+		font-size: 16px
+	}
+}
+
+.shariff .facebook a {
+	background-color: #3b5998
+}
+
+.shariff .facebook a:hover {
+	background-color: #4273c8
+}
+
+.shariff .facebook .fa-facebook-f {
+	font-size: 22px
+}
+
+.shariff .facebook .share_count {
+	color: #183a75;
+	background-color: #99adcf
+}
+
+.shariff .theme-white .facebook a {
+	color: #3b5998
+}
+
+@media only screen and (min-width:600px) {
+	.shariff .facebook .fa-facebook-f {
+		font-size: 19px
+	}
+}
+
+.shariff .flattr a {
+	background-color: #7ea352
+}
+
+.shariff .flattr a:hover {
+	background-color: #f67c1a
+}
+
+.shariff .flattr a:hover .share_count {
+	color: #d56308;
+	background-color: #fab47c
+}
+
+.shariff .flattr .fa-money-bill-alt {
+	font-size: 22px
+}
+
+.shariff .flattr .share_count {
+	color: #648141;
+	background-color: #b0c893
+}
+
+.shariff .theme-white .flattr a {
+	color: #f67c1a
+}
+
+@media only screen and (min-width:600px) {
+	.shariff .flattr .fa-money-bill-alt {
+		font-size: 19px
+	}
+}
+
+.shariff .flipboard a {
+	background-color: #e12828
+}
+
+.shariff .flipboard a:hover {
+	background-color: #ff2e2e
+}
+
+.shariff .flipboard .fa-flipboard {
+	font-size: 22px
+}
+
+.shariff .theme-white .flipboard a {
+	color: #e12828
+}
+
+@media only screen and (min-width:600px) {
+	.shariff .flipboard .fa-flipboard {
+		font-size: 19px
+	}
+}
+
+.shariff .googleplus a {
+	background-color: #d34836
+}
+
+.shariff .googleplus a:hover {
+	background-color: #f75b44
+}
+
+.shariff .googleplus .fa-google-plus-g {
+	font-size: 22px
+}
+
+.shariff .googleplus .share_count {
+	color: #a31601;
+	background-color: #eda79d
+}
+
+.shariff .theme-white .googleplus a {
+	color: #d34836
+}
+
+@media only screen and (min-width:600px) {
+	.shariff .googleplus .fa-google-plus-g {
+		font-size: 19px
+	}
+}
+
+.shariff .info {
+	border: 1px solid #ccc
+}
+
+.shariff .info a {
+	color: #666;
+	background-color: #fff
+}
+
+.shariff .info a:hover {
+	background-color: #efefef
+}
+
+.shariff .info .fa-info {
+	font-size: 20px;
+	width: 33px
+}
+
+.shariff .info .share_text {
+	display: block!important;
+	text-indent: -9999px!important
+}
+
+.shariff .theme-grey .info a {
+	background-color: #fff
+}
+
+.shariff .theme-grey .info a:hover {
+	background-color: #efefef
+}
+
+.shariff .orientation-vertical .info {
+	width: 35px;
+	float: right
+}
+
+@media only screen and (min-width:360px) {
+	.shariff .orientation-horizontal .info {
+		-webkit-box-flex: 0!important;
+		-ms-flex: none!important;
+		flex: none!important;
+		width: 35px;
+		min-width: 35px!important
+	}
+}
+
+@media only screen and (min-width:1024px) {
+	.shariff .info .fa-info {
+		font-size: 16px;
+		width: 23px
+	}
+	.shariff .orientation-horizontal .info {
+		width: 25px;
+		min-width: 25px!important
+	}
+	.shariff .orientation-vertical .info {
+		width: 25px
+	}
+}
+
+.shariff .linkedin a {
+	background-color: #0077b5
+}
+
+.shariff .linkedin a:hover {
+	background-color: #0369a0
+}
+
+.shariff .linkedin .fa-linkedin-in {
+	font-size: 22px
+}
+
+.shariff .linkedin .share_count {
+	color: #004785;
+	background-color: #33aae8
+}
+
+.shariff .theme-white .linkedin a {
+	color: #0077b5
+}
+
+@media only screen and (min-width:600px) {
+	.shariff .linkedin .fa-linkedin-in {
+		font-size: 19px
+	}
+}
+
+.shariff .mail a {
+	background-color: #999
+}
+
+.shariff .mail a:hover {
+	background-color: #a8a8a8
+}
+
+.shariff .mail .fa-envelope {
+	font-size: 21px
+}
+
+.shariff .theme-white .mail a {
+	color: #999
+}
+
+@media only screen and (min-width:600px) {
+	.shariff .mail .fa-envelope {
+		font-size: 18px
+	}
+}
+
+.shariff .print a {
+	background-color: #999
+}
+
+.shariff .print a:hover {
+	background-color: #a8a8a8
+}
+
+.shariff .print .fa-print {
+	font-size: 21px
+}
+
+.shariff .theme-white .print a {
+	color: #999
+}
+
+@media only screen and (min-width:600px) {
+	.shariff .print .fa-print {
+		font-size: 18px
+	}
+}
+
+.shariff .pinterest a {
+	background-color: #bd081c
+}
+
+.shariff .pinterest a:hover {
+	background-color: #d50920
+}
+
+.shariff .pinterest .fa-pinterest-p {
+	font-size: 22px
+}
+
+.shariff .pinterest .share_count {
+	color: #a31601;
+	background-color: #eda79d
+}
+
+.shariff .theme-white .pinterest a {
+	color: #bd081c
+}
+
+@media only screen and (min-width:600px) {
+	.shariff .pinterest .fa-pinterest-p {
+		font-size: 19px;
+		position: relative;
+		top: 1px
+	}
+}
+
+.shariff .reddit a {
+	background-color: #ff4500
+}
+
+.shariff .reddit a:hover {
+	background-color: #ff6a33
+}
+
+.shariff .reddit .fa-reddit {
+	font-size: 17px
+}
+
+.shariff .theme-white .reddit a {
+	color: #ff4500
+}
+
+@media only screen and (min-width:600px) {
+	.shariff .reddit .fa-reddit {
+		font-size: 16px
+	}
+}
+
+.shariff .stumbleupon a {
+	background-color: #eb4924
+}
+
+.shariff .stumbleupon a:hover {
+	background-color: #ef7053
+}
+
+.shariff .stumbleupon .fa-stumbleupon {
+	font-size: 17px
+}
+
+.shariff .theme-white .stumbleupon a {
+	color: #eb4924
+}
+
+@media only screen and (min-width:600px) {
+	.shariff .stumbleupon .fa-stumbleupon {
+		font-size: 16px
+	}
+}
+
+.shariff .twitter a {
+	background-color: #55acee
+}
+
+.shariff .twitter a:hover {
+	background-color: #32bbf5
+}
+
+.shariff .twitter .fa-twitter {
+	font-size: 28px
+}
+
+.shariff .twitter .share_count {
+	color: #0174a4;
+	background-color: #96d4ee
+}
+
+.shariff .theme-white .twitter a {
+	color: #55acee
+}
+
+@media only screen and (min-width:600px) {
+	.shariff .twitter .fa-twitter {
+		font-size: 24px
+	}
+}
+
+.shariff .whatsapp a {
+	background-color: #5cbe4a
+}
+
+.shariff .whatsapp a:hover {
+	background-color: #34af23
+}
+
+.shariff .whatsapp .fa-whatsapp {
+	font-size: 28px
+}
+
+.shariff .theme-white .whatsapp a {
+	color: #5cbe4a
+}
+
+@media only screen and (min-width:600px) {
+	.shariff .whatsapp .fa-whatsapp {
+		font-size: 22px
+	}
+}
+
+.shariff .xing a {
+	background-color: #126567
+}
+
+.shariff .xing a:hover {
+	background-color: #29888a
+}
+
+.shariff .xing .fa-xing {
+	font-size: 22px
+}
+
+.shariff .xing .share_count {
+	color: #15686a;
+	background-color: #4fa5a7
+}
+
+.shariff .theme-white .xing a {
+	color: #126567
+}
+
+@media only screen and (min-width:600px) {
+	.shariff .xing .fa-xing {
+		font-size: 19px
+	}
+}
+
+.shariff .tumblr a {
+	background-color: #36465d
+}
+
+.shariff .tumblr a:hover {
+	background-color: #44546b
+}
+
+.shariff .tumblr .fa-tumblr {
+	font-size: 28px
+}
+
+.shariff .theme-white .tumblr a {
+	color: #5cbe4a
+}
+
+@media only screen and (min-width:600px) {
+	.shariff .tumblr .fa-tumblr {
+		font-size: 22px
+	}
+}
+
+.shariff .threema a {
+	background-color: #333
+}
+
+.shariff .threema a:hover {
+	background-color: #1f1f1f
+}
+
+.shariff .threema .fa-lock {
+	font-size: 28px
+}
+
+.shariff .theme-white .threema a {
+	color: #333
+}
+
+@media only screen and (min-width:600px) {
+	.shariff .threema .fa-lock {
+		font-size: 22px
+	}
+}
+
+.shariff .weibo a {
+	background-color: #f56770
+}
+
+.shariff .weibo a:hover {
+	background-color: #fa7f8a
+}
+
+.shariff .weibo .fa-weibo {
+	font-size: 28px
+}
+
+.shariff .weibo .share_count {
+	color: #0174a4;
+	background-color: #f56770
+}
+
+.shariff .theme-white .weibo a {
+	color: #f56770
+}
+
+@media only screen and (min-width:600px) {
+	.shariff .weibo .fa-weibo {
+		font-size: 24px
+	}
+}
+
+.shariff .tencent-weibo a {
+	background-color: #26ace0
+}
+
+.shariff .tencent-weibo a:hover {
+	background-color: #38bbeb
+}
+
+.shariff .tencent-weibo .fa-tencent-weibo {
+	font-size: 28px
+}
+
+.shariff .tencent-weibo .share_count {
+	color: #0174a4;
+	background-color: #26ace0
+}
+
+.shariff .theme-white .tencent-weibo a {
+	color: #26ace0
+}
+
+@media only screen and (min-width:600px) {
+	.shariff .tencent-weibo .fa-tencent-weibo {
+		font-size: 24px
+	}
+}
+
+.shariff .telegram a {
+	background-color: #08c
+}
+
+.shariff .telegram a:hover {
+	background-color: #007dbb
+}
+
+.shariff .telegram .fa-telegram {
+	font-size: 28px
+}
+
+.shariff .theme-white .telegram a {
+	color: #08c
+}
+
+@media only screen and (min-width:600px) {
+	.shariff .telegram .fa-telegram {
+		font-size: 22px
+	}
+}
+
+.shariff .qzone a {
+	background-color: #2b82d9
+}
+
+.shariff .qzone a:hover {
+	background-color: #398fe6
+}
+
+.shariff .qzone .fa-qq {
+	font-size: 28px
+}
+
+.shariff .qzone .share_count {
+	color: #0174a4;
+	background-color: #2b82d9
+}
+
+.shariff .theme-white .qzone a {
+	color: #2b82d9
+}
+
+@media only screen and (min-width:600px) {
+	.shariff .qzone .fa-qq {
+		font-size: 24px
+	}
+}
+
+.shariff .vk a {
+	background-color: #5d7fa4
+}
+
+.shariff .vk a:hover {
+	background-color: #678eb4
+}
+
+.shariff .vk .fa-vk {
+	font-size: 22px
+}
+
+.shariff .vk .share_count {
+	color: #55677d;
+	background-color: #fff
+}
+
+.shariff .theme-white .vk a {
+	color: #3b5998
+}
+
+@media only screen and (min-width:600px) {
+	.shariff .vk .fa-vk {
+		font-size: 19px
+	}
+}

--- a/shariff.min.css
+++ b/shariff.min.css
@@ -8,3551 +8,3551 @@
  * Font Awesome Free 5.0.5 by @fontawesome - http://fontawesome.com
  * License - http://fontawesome.com/license (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License)
  */
-.fa,
-.fab,
-.fal,
-.far,
-.fas {
-	-moz-osx-font-smoothing: grayscale;
-	-webkit-font-smoothing: antialiased;
-	display: inline-block;
-	font-style: normal;
-	font-variant: normal;
-	text-rendering: auto;
-	line-height: 1
-}
-
-.fa-lg {
-	font-size: 1.33333333em;
-	line-height: .75em;
-	vertical-align: -.0667em
-}
-
-.fa-xs {
-	font-size: .75em
-}
-
-.fa-sm {
-	font-size: .875em
-}
-
-.fa-1x {
-	font-size: 1em
-}
-
-.fa-2x {
-	font-size: 2em
-}
-
-.fa-3x {
-	font-size: 3em
-}
-
-.fa-4x {
-	font-size: 4em
-}
-
-.fa-5x {
-	font-size: 5em
-}
-
-.fa-6x {
-	font-size: 6em
-}
-
-.fa-7x {
-	font-size: 7em
-}
-
-.fa-8x {
-	font-size: 8em
-}
-
-.fa-9x {
-	font-size: 9em
-}
-
-.fa-10x {
-	font-size: 10em
-}
-
-.fa-fw {
-	text-align: center;
-	width: 1.25em
-}
-
-.fa-ul {
-	list-style-type: none;
-	margin-left: 2em * 5/4;
-	padding-left: 0
-}
-
-.fa-ul>li {
-	position: relative
-}
-
-.fa-li {
-	left: -2em;
-	position: absolute;
-	text-align: center;
-	width: 2em;
-	line-height: inherit
-}
-
-.fa-border {
-	border-radius: .1em;
-	border: .08em solid #eee;
-	padding: .2em .25em .15em
-}
-
-.fa-pull-left {
-	float: left
-}
-
-.fa-pull-right {
-	float: right
-}
-
-.fa.fa-pull-left,
-.fab.fa-pull-left,
-.fal.fa-pull-left,
-.far.fa-pull-left,
-.fas.fa-pull-left {
-	margin-right: .3em
-}
-
-.fa.fa-pull-right,
-.fab.fa-pull-right,
-.fal.fa-pull-right,
-.far.fa-pull-right,
-.fas.fa-pull-right {
-	margin-left: .3em
-}
-
-.fa-spin {
-	-webkit-animation: fa-spin 2s infinite linear;
-	animation: fa-spin 2s infinite linear
-}
-
-.fa-pulse {
-	-webkit-animation: fa-spin 1s infinite steps(8);
-	animation: fa-spin 1s infinite steps(8)
-}
-
-@-webkit-keyframes fa-spin {
-	0% {
-		-webkit-transform: rotate(0deg);
-		transform: rotate(0deg)
-	}
-	to {
-		-webkit-transform: rotate(1turn);
-		transform: rotate(1turn)
-	}
-}
-
-@keyframes fa-spin {
-	0% {
-		-webkit-transform: rotate(0deg);
-		transform: rotate(0deg)
-	}
-	to {
-		-webkit-transform: rotate(1turn);
-		transform: rotate(1turn)
-	}
-}
-
-.fa-rotate-90 {
-	-ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=1)";
-	-webkit-transform: rotate(90deg);
-	transform: rotate(90deg)
-}
-
-.fa-rotate-180 {
-	-ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=2)";
-	-webkit-transform: rotate(180deg);
-	transform: rotate(180deg)
-}
-
-.fa-rotate-270 {
-	-ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=3)";
-	-webkit-transform: rotate(270deg);
-	transform: rotate(270deg)
-}
-
-.fa-flip-horizontal {
-	-ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=0, mirror=1)";
-	-webkit-transform: scaleX(-1);
-	transform: scaleX(-1)
-}
-
-.fa-flip-vertical {
-	-webkit-transform: scaleY(-1);
-	transform: scaleY(-1)
-}
-
-.fa-flip-horizontal.fa-flip-vertical,
-.fa-flip-vertical {
-	-ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=2, mirror=1)"
-}
-
-.fa-flip-horizontal.fa-flip-vertical {
-	-webkit-transform: scale(-1);
-	transform: scale(-1)
-}
-
-:root .fa-flip-horizontal,
-:root .fa-flip-vertical,
-:root .fa-rotate-90,
-:root .fa-rotate-180,
-:root .fa-rotate-270 {
-	-webkit-filter: none;
-	filter: none
-}
-
-.fa-stack {
-	display: inline-block;
-	height: 2em;
-	line-height: 2em;
-	position: relative;
-	vertical-align: middle;
-	width: 2em
-}
-
-.fa-stack-1x,
-.fa-stack-2x {
-	left: 0;
-	position: absolute;
-	text-align: center;
-	width: 100%
-}
-
-.fa-stack-1x {
-	line-height: inherit
-}
-
-.fa-stack-2x {
-	font-size: 2em
-}
-
-.fa-inverse {
-	color: #fff
-}
-
-.fa-500px:before {
-	content: "\F26E"
-}
-
-.fa-accessible-icon:before {
-	content: "\F368"
-}
-
-.fa-accusoft:before {
-	content: "\F369"
-}
-
-.fa-address-book:before {
-	content: "\F2B9"
-}
-
-.fa-address-card:before {
-	content: "\F2BB"
-}
-
-.fa-adjust:before {
-	content: "\F042"
-}
-
-.fa-adn:before {
-	content: "\F170"
-}
-
-.fa-adversal:before {
-	content: "\F36A"
-}
-
-.fa-affiliatetheme:before {
-	content: "\F36B"
-}
-
-.fa-algolia:before {
-	content: "\F36C"
-}
-
-.fa-align-center:before {
-	content: "\F037"
-}
-
-.fa-align-justify:before {
-	content: "\F039"
-}
-
-.fa-align-left:before {
-	content: "\F036"
-}
-
-.fa-align-right:before {
-	content: "\F038"
-}
-
-.fa-amazon:before {
-	content: "\F270"
-}
-
-.fa-amazon-pay:before {
-	content: "\F42C"
-}
-
-.fa-ambulance:before {
-	content: "\F0F9"
-}
-
-.fa-american-sign-language-interpreting:before {
-	content: "\F2A3"
-}
-
-.fa-amilia:before {
-	content: "\F36D"
-}
-
-.fa-anchor:before {
-	content: "\F13D"
-}
-
-.fa-android:before {
-	content: "\F17B"
-}
-
-.fa-angellist:before {
-	content: "\F209"
-}
-
-.fa-angle-double-down:before {
-	content: "\F103"
-}
-
-.fa-angle-double-left:before {
-	content: "\F100"
-}
-
-.fa-angle-double-right:before {
-	content: "\F101"
-}
-
-.fa-angle-double-up:before {
-	content: "\F102"
-}
-
-.fa-angle-down:before {
-	content: "\F107"
-}
-
-.fa-angle-left:before {
-	content: "\F104"
-}
-
-.fa-angle-right:before {
-	content: "\F105"
-}
-
-.fa-angle-up:before {
-	content: "\F106"
-}
-
-.fa-angrycreative:before {
-	content: "\F36E"
-}
-
-.fa-angular:before {
-	content: "\F420"
-}
-
-.fa-app-store:before {
-	content: "\F36F"
-}
-
-.fa-app-store-ios:before {
-	content: "\F370"
-}
-
-.fa-apper:before {
-	content: "\F371"
-}
-
-.fa-apple:before {
-	content: "\F179"
-}
-
-.fa-apple-pay:before {
-	content: "\F415"
-}
-
-.fa-archive:before {
-	content: "\F187"
-}
-
-.fa-arrow-alt-circle-down:before {
-	content: "\F358"
-}
-
-.fa-arrow-alt-circle-left:before {
-	content: "\F359"
-}
-
-.fa-arrow-alt-circle-right:before {
-	content: "\F35A"
-}
-
-.fa-arrow-alt-circle-up:before {
-	content: "\F35B"
-}
-
-.fa-arrow-circle-down:before {
-	content: "\F0AB"
-}
-
-.fa-arrow-circle-left:before {
-	content: "\F0A8"
-}
-
-.fa-arrow-circle-right:before {
-	content: "\F0A9"
-}
-
-.fa-arrow-circle-up:before {
-	content: "\F0AA"
-}
-
-.fa-arrow-down:before {
-	content: "\F063"
-}
-
-.fa-arrow-left:before {
-	content: "\F060"
-}
-
-.fa-arrow-right:before {
-	content: "\F061"
-}
-
-.fa-arrow-up:before {
-	content: "\F062"
-}
-
-.fa-arrows-alt:before {
-	content: "\F0B2"
-}
-
-.fa-arrows-alt-h:before {
-	content: "\F337"
-}
-
-.fa-arrows-alt-v:before {
-	content: "\F338"
-}
-
-.fa-assistive-listening-systems:before {
-	content: "\F2A2"
-}
-
-.fa-asterisk:before {
-	content: "\F069"
-}
-
-.fa-asymmetrik:before {
-	content: "\F372"
-}
-
-.fa-at:before {
-	content: "\F1FA"
-}
-
-.fa-audible:before {
-	content: "\F373"
-}
-
-.fa-audio-description:before {
-	content: "\F29E"
-}
-
-.fa-autoprefixer:before {
-	content: "\F41C"
-}
-
-.fa-avianex:before {
-	content: "\F374"
-}
-
-.fa-aviato:before {
-	content: "\F421"
-}
-
-.fa-aws:before {
-	content: "\F375"
-}
-
-.fa-backward:before {
-	content: "\F04A"
-}
-
-.fa-balance-scale:before {
-	content: "\F24E"
-}
-
-.fa-ban:before {
-	content: "\F05E"
-}
-
-.fa-bandcamp:before {
-	content: "\F2D5"
-}
-
-.fa-barcode:before {
-	content: "\F02A"
-}
-
-.fa-bars:before {
-	content: "\F0C9"
-}
-
-.fa-baseball-ball:before {
-	content: "\F433"
-}
-
-.fa-basketball-ball:before {
-	content: "\F434"
-}
-
-.fa-bath:before {
-	content: "\F2CD"
-}
-
-.fa-battery-empty:before {
-	content: "\F244"
-}
-
-.fa-battery-full:before {
-	content: "\F240"
-}
-
-.fa-battery-half:before {
-	content: "\F242"
-}
-
-.fa-battery-quarter:before {
-	content: "\F243"
-}
-
-.fa-battery-three-quarters:before {
-	content: "\F241"
-}
-
-.fa-bed:before {
-	content: "\F236"
-}
-
-.fa-beer:before {
-	content: "\F0FC"
-}
-
-.fa-behance:before {
-	content: "\F1B4"
-}
-
-.fa-behance-square:before {
-	content: "\F1B5"
-}
-
-.fa-bell:before {
-	content: "\F0F3"
-}
-
-.fa-bell-slash:before {
-	content: "\F1F6"
-}
-
-.fa-bicycle:before {
-	content: "\F206"
-}
-
-.fa-bimobject:before {
-	content: "\F378"
-}
-
-.fa-binoculars:before {
-	content: "\F1E5"
-}
-
-.fa-birthday-cake:before {
-	content: "\F1FD"
-}
-
-.fa-bitbucket:before {
-	content: "\F171"
-}
-
-.fa-bitcoin:before {
-	content: "\F379"
-}
-
-.fa-bity:before {
-	content: "\F37A"
-}
-
-.fa-black-tie:before {
-	content: "\F27E"
-}
-
-.fa-blackberry:before {
-	content: "\F37B"
-}
-
-.fa-blind:before {
-	content: "\F29D"
-}
-
-.fa-blogger:before {
-	content: "\F37C"
-}
-
-.fa-blogger-b:before {
-	content: "\F37D"
-}
-
-.fa-bluetooth:before {
-	content: "\F293"
-}
-
-.fa-bluetooth-b:before {
-	content: "\F294"
-}
-
-.fa-bold:before {
-	content: "\F032"
-}
-
-.fa-bolt:before {
-	content: "\F0E7"
-}
-
-.fa-bomb:before {
-	content: "\F1E2"
-}
-
-.fa-book:before {
-	content: "\F02D"
-}
-
-.fa-bookmark:before {
-	content: "\F02E"
-}
-
-.fa-bowling-ball:before {
-	content: "\F436"
-}
-
-.fa-braille:before {
-	content: "\F2A1"
-}
-
-.fa-briefcase:before {
-	content: "\F0B1"
-}
-
-.fa-btc:before {
-	content: "\F15A"
-}
-
-.fa-bug:before {
-	content: "\F188"
-}
-
-.fa-building:before {
-	content: "\F1AD"
-}
-
-.fa-bullhorn:before {
-	content: "\F0A1"
-}
-
-.fa-bullseye:before {
-	content: "\F140"
-}
-
-.fa-buromobelexperte:before {
-	content: "\F37F"
-}
-
-.fa-bus:before {
-	content: "\F207"
-}
-
-.fa-buysellads:before {
-	content: "\F20D"
-}
-
-.fa-calculator:before {
-	content: "\F1EC"
-}
-
-.fa-calendar:before {
-	content: "\F133"
-}
-
-.fa-calendar-alt:before {
-	content: "\F073"
-}
-
-.fa-calendar-check:before {
-	content: "\F274"
-}
-
-.fa-calendar-minus:before {
-	content: "\F272"
-}
-
-.fa-calendar-plus:before {
-	content: "\F271"
-}
-
-.fa-calendar-times:before {
-	content: "\F273"
-}
-
-.fa-camera:before {
-	content: "\F030"
-}
-
-.fa-camera-retro:before {
-	content: "\F083"
-}
-
-.fa-car:before {
-	content: "\F1B9"
-}
-
-.fa-caret-down:before {
-	content: "\F0D7"
-}
-
-.fa-caret-left:before {
-	content: "\F0D9"
-}
-
-.fa-caret-right:before {
-	content: "\F0DA"
-}
-
-.fa-caret-square-down:before {
-	content: "\F150"
-}
-
-.fa-caret-square-left:before {
-	content: "\F191"
-}
-
-.fa-caret-square-right:before {
-	content: "\F152"
-}
-
-.fa-caret-square-up:before {
-	content: "\F151"
-}
-
-.fa-caret-up:before {
-	content: "\F0D8"
-}
-
-.fa-cart-arrow-down:before {
-	content: "\F218"
-}
-
-.fa-cart-plus:before {
-	content: "\F217"
-}
-
-.fa-cc-amazon-pay:before {
-	content: "\F42D"
-}
-
-.fa-cc-amex:before {
-	content: "\F1F3"
-}
-
-.fa-cc-apple-pay:before {
-	content: "\F416"
-}
-
-.fa-cc-diners-club:before {
-	content: "\F24C"
-}
-
-.fa-cc-discover:before {
-	content: "\F1F2"
-}
-
-.fa-cc-jcb:before {
-	content: "\F24B"
-}
-
-.fa-cc-mastercard:before {
-	content: "\F1F1"
-}
-
-.fa-cc-paypal:before {
-	content: "\F1F4"
-}
-
-.fa-cc-stripe:before {
-	content: "\F1F5"
-}
-
-.fa-cc-visa:before {
-	content: "\F1F0"
-}
-
-.fa-centercode:before {
-	content: "\F380"
-}
-
-.fa-certificate:before {
-	content: "\F0A3"
-}
-
-.fa-chart-area:before {
-	content: "\F1FE"
-}
-
-.fa-chart-bar:before {
-	content: "\F080"
-}
-
-.fa-chart-line:before {
-	content: "\F201"
-}
-
-.fa-chart-pie:before {
-	content: "\F200"
-}
-
-.fa-check:before {
-	content: "\F00C"
-}
-
-.fa-check-circle:before {
-	content: "\F058"
-}
-
-.fa-check-square:before {
-	content: "\F14A"
-}
-
-.fa-chess:before {
-	content: "\F439"
-}
-
-.fa-chess-bishop:before {
-	content: "\F43A"
-}
-
-.fa-chess-board:before {
-	content: "\F43C"
-}
-
-.fa-chess-king:before {
-	content: "\F43F"
-}
-
-.fa-chess-knight:before {
-	content: "\F441"
-}
-
-.fa-chess-pawn:before {
-	content: "\F443"
-}
-
-.fa-chess-queen:before {
-	content: "\F445"
-}
-
-.fa-chess-rook:before {
-	content: "\F447"
-}
-
-.fa-chevron-circle-down:before {
-	content: "\F13A"
-}
-
-.fa-chevron-circle-left:before {
-	content: "\F137"
-}
-
-.fa-chevron-circle-right:before {
-	content: "\F138"
-}
-
-.fa-chevron-circle-up:before {
-	content: "\F139"
-}
-
-.fa-chevron-down:before {
-	content: "\F078"
-}
-
-.fa-chevron-left:before {
-	content: "\F053"
-}
-
-.fa-chevron-right:before {
-	content: "\F054"
-}
-
-.fa-chevron-up:before {
-	content: "\F077"
-}
-
-.fa-child:before {
-	content: "\F1AE"
-}
-
-.fa-chrome:before {
-	content: "\F268"
-}
-
-.fa-circle:before {
-	content: "\F111"
-}
-
-.fa-circle-notch:before {
-	content: "\F1CE"
-}
-
-.fa-clipboard:before {
-	content: "\F328"
-}
-
-.fa-clock:before {
-	content: "\F017"
-}
-
-.fa-clone:before {
-	content: "\F24D"
-}
-
-.fa-closed-captioning:before {
-	content: "\F20A"
-}
-
-.fa-cloud:before {
-	content: "\F0C2"
-}
-
-.fa-cloud-download-alt:before {
-	content: "\F381"
-}
-
-.fa-cloud-upload-alt:before {
-	content: "\F382"
-}
-
-.fa-cloudscale:before {
-	content: "\F383"
-}
-
-.fa-cloudsmith:before {
-	content: "\F384"
-}
-
-.fa-cloudversify:before {
-	content: "\F385"
-}
-
-.fa-code:before {
-	content: "\F121"
-}
-
-.fa-code-branch:before {
-	content: "\F126"
-}
-
-.fa-codepen:before {
-	content: "\F1CB"
-}
-
-.fa-codiepie:before {
-	content: "\F284"
-}
-
-.fa-coffee:before {
-	content: "\F0F4"
-}
-
-.fa-cog:before {
-	content: "\F013"
-}
-
-.fa-cogs:before {
-	content: "\F085"
-}
-
-.fa-columns:before {
-	content: "\F0DB"
-}
-
-.fa-comment:before {
-	content: "\F075"
-}
-
-.fa-comment-alt:before {
-	content: "\F27A"
-}
-
-.fa-comments:before {
-	content: "\F086"
-}
-
-.fa-compass:before {
-	content: "\F14E"
-}
-
-.fa-compress:before {
-	content: "\F066"
-}
-
-.fa-connectdevelop:before {
-	content: "\F20E"
-}
-
-.fa-contao:before {
-	content: "\F26D"
-}
-
-.fa-copy:before {
-	content: "\F0C5"
-}
-
-.fa-copyright:before {
-	content: "\F1F9"
-}
-
-.fa-cpanel:before {
-	content: "\F388"
-}
-
-.fa-creative-commons:before {
-	content: "\F25E"
-}
-
-.fa-credit-card:before {
-	content: "\F09D"
-}
-
-.fa-crop:before {
-	content: "\F125"
-}
-
-.fa-crosshairs:before {
-	content: "\F05B"
-}
-
-.fa-css3:before {
-	content: "\F13C"
-}
-
-.fa-css3-alt:before {
-	content: "\F38B"
-}
-
-.fa-cube:before {
-	content: "\F1B2"
-}
-
-.fa-cubes:before {
-	content: "\F1B3"
-}
-
-.fa-cut:before {
-	content: "\F0C4"
-}
-
-.fa-cuttlefish:before {
-	content: "\F38C"
-}
-
-.fa-d-and-d:before {
-	content: "\F38D"
-}
-
-.fa-dashcube:before {
-	content: "\F210"
-}
-
-.fa-database:before {
-	content: "\F1C0"
-}
-
-.fa-deaf:before {
-	content: "\F2A4"
-}
-
-.fa-delicious:before {
-	content: "\F1A5"
-}
-
-.fa-deploydog:before {
-	content: "\F38E"
-}
-
-.fa-deskpro:before {
-	content: "\F38F"
-}
-
-.fa-desktop:before {
-	content: "\F108"
-}
-
-.fa-deviantart:before {
-	content: "\F1BD"
-}
-
-.fa-digg:before {
-	content: "\F1A6"
-}
-
-.fa-digital-ocean:before {
-	content: "\F391"
-}
-
-.fa-discord:before {
-	content: "\F392"
-}
-
-.fa-discourse:before {
-	content: "\F393"
-}
-
-.fa-dochub:before {
-	content: "\F394"
-}
-
-.fa-docker:before {
-	content: "\F395"
-}
-
-.fa-dollar-sign:before {
-	content: "\F155"
-}
-
-.fa-dot-circle:before {
-	content: "\F192"
-}
-
-.fa-download:before {
-	content: "\F019"
-}
-
-.fa-draft2digital:before {
-	content: "\F396"
-}
-
-.fa-dribbble:before {
-	content: "\F17D"
-}
-
-.fa-dribbble-square:before {
-	content: "\F397"
-}
-
-.fa-dropbox:before {
-	content: "\F16B"
-}
-
-.fa-drupal:before {
-	content: "\F1A9"
-}
-
-.fa-dyalog:before {
-	content: "\F399"
-}
-
-.fa-earlybirds:before {
-	content: "\F39A"
-}
-
-.fa-edge:before {
-	content: "\F282"
-}
-
-.fa-edit:before {
-	content: "\F044"
-}
-
-.fa-eject:before {
-	content: "\F052"
-}
-
-.fa-elementor:before {
-	content: "\F430"
-}
-
-.fa-ellipsis-h:before {
-	content: "\F141"
-}
-
-.fa-ellipsis-v:before {
-	content: "\F142"
-}
-
-.fa-ember:before {
-	content: "\F423"
-}
-
-.fa-empire:before {
-	content: "\F1D1"
-}
-
-.fa-envelope:before {
-	content: "\F0E0"
-}
-
-.fa-envelope-open:before {
-	content: "\F2B6"
-}
-
-.fa-envelope-square:before {
-	content: "\F199"
-}
-
-.fa-envira:before {
-	content: "\F299"
-}
-
-.fa-eraser:before {
-	content: "\F12D"
-}
-
-.fa-erlang:before {
-	content: "\F39D"
-}
-
-.fa-ethereum:before {
-	content: "\F42E"
-}
-
-.fa-etsy:before {
-	content: "\F2D7"
-}
-
-.fa-euro-sign:before {
-	content: "\F153"
-}
-
-.fa-exchange-alt:before {
-	content: "\F362"
-}
-
-.fa-exclamation:before {
-	content: "\F12A"
-}
-
-.fa-exclamation-circle:before {
-	content: "\F06A"
-}
-
-.fa-exclamation-triangle:before {
-	content: "\F071"
-}
-
-.fa-expand:before {
-	content: "\F065"
-}
-
-.fa-expand-arrows-alt:before {
-	content: "\F31E"
-}
-
-.fa-expeditedssl:before {
-	content: "\F23E"
-}
-
-.fa-external-link-alt:before {
-	content: "\F35D"
-}
-
-.fa-external-link-square-alt:before {
-	content: "\F360"
-}
-
-.fa-eye:before {
-	content: "\F06E"
-}
-
-.fa-eye-dropper:before {
-	content: "\F1FB"
-}
-
-.fa-eye-slash:before {
-	content: "\F070"
-}
-
-.fa-facebook:before {
-	content: "\F09A"
-}
-
-.fa-facebook-f:before {
-	content: "\F39E"
-}
-
-.fa-facebook-messenger:before {
-	content: "\F39F"
-}
-
-.fa-facebook-square:before {
-	content: "\F082"
-}
-
-.fa-fast-backward:before {
-	content: "\F049"
-}
-
-.fa-fast-forward:before {
-	content: "\F050"
-}
-
-.fa-fax:before {
-	content: "\F1AC"
-}
-
-.fa-female:before {
-	content: "\F182"
-}
-
-.fa-fighter-jet:before {
-	content: "\F0FB"
-}
-
-.fa-file:before {
-	content: "\F15B"
-}
-
-.fa-file-alt:before {
-	content: "\F15C"
-}
-
-.fa-file-archive:before {
-	content: "\F1C6"
-}
-
-.fa-file-audio:before {
-	content: "\F1C7"
-}
-
-.fa-file-code:before {
-	content: "\F1C9"
-}
-
-.fa-file-excel:before {
-	content: "\F1C3"
-}
-
-.fa-file-image:before {
-	content: "\F1C5"
-}
-
-.fa-file-pdf:before {
-	content: "\F1C1"
-}
-
-.fa-file-powerpoint:before {
-	content: "\F1C4"
-}
-
-.fa-file-video:before {
-	content: "\F1C8"
-}
-
-.fa-file-word:before {
-	content: "\F1C2"
-}
-
-.fa-film:before {
-	content: "\F008"
-}
-
-.fa-filter:before {
-	content: "\F0B0"
-}
-
-.fa-fire:before {
-	content: "\F06D"
-}
-
-.fa-fire-extinguisher:before {
-	content: "\F134"
-}
-
-.fa-firefox:before {
-	content: "\F269"
-}
-
-.fa-first-order:before {
-	content: "\F2B0"
-}
-
-.fa-firstdraft:before {
-	content: "\F3A1"
-}
-
-.fa-flag:before {
-	content: "\F024"
-}
-
-.fa-flag-checkered:before {
-	content: "\F11E"
-}
-
-.fa-flask:before {
-	content: "\F0C3"
-}
-
-.fa-flickr:before {
-	content: "\F16E"
-}
-
-.fa-flipboard:before {
-	content: "\F44D"
-}
-
-.fa-fly:before {
-	content: "\F417"
-}
-
-.fa-folder:before {
-	content: "\F07B"
-}
-
-.fa-folder-open:before {
-	content: "\F07C"
-}
-
-.fa-font:before {
-	content: "\F031"
-}
-
-.fa-font-awesome:before {
-	content: "\F2B4"
-}
-
-.fa-font-awesome-alt:before {
-	content: "\F35C"
-}
-
-.fa-font-awesome-flag:before {
-	content: "\F425"
-}
-
-.fa-fonticons:before {
-	content: "\F280"
-}
-
-.fa-fonticons-fi:before {
-	content: "\F3A2"
-}
-
-.fa-football-ball:before {
-	content: "\F44E"
-}
-
-.fa-fort-awesome:before {
-	content: "\F286"
-}
-
-.fa-fort-awesome-alt:before {
-	content: "\F3A3"
-}
-
-.fa-forumbee:before {
-	content: "\F211"
-}
-
-.fa-forward:before {
-	content: "\F04E"
-}
-
-.fa-foursquare:before {
-	content: "\F180"
-}
-
-.fa-free-code-camp:before {
-	content: "\F2C5"
-}
-
-.fa-freebsd:before {
-	content: "\F3A4"
-}
-
-.fa-frown:before {
-	content: "\F119"
-}
-
-.fa-futbol:before {
-	content: "\F1E3"
-}
-
-.fa-gamepad:before {
-	content: "\F11B"
-}
-
-.fa-gavel:before {
-	content: "\F0E3"
-}
-
-.fa-gem:before {
-	content: "\F3A5"
-}
-
-.fa-genderless:before {
-	content: "\F22D"
-}
-
-.fa-get-pocket:before {
-	content: "\F265"
-}
-
-.fa-gg:before {
-	content: "\F260"
-}
-
-.fa-gg-circle:before {
-	content: "\F261"
-}
-
-.fa-gift:before {
-	content: "\F06B"
-}
-
-.fa-git:before {
-	content: "\F1D3"
-}
-
-.fa-git-square:before {
-	content: "\F1D2"
-}
-
-.fa-github:before {
-	content: "\F09B"
-}
-
-.fa-github-alt:before {
-	content: "\F113"
-}
-
-.fa-github-square:before {
-	content: "\F092"
-}
-
-.fa-gitkraken:before {
-	content: "\F3A6"
-}
-
-.fa-gitlab:before {
-	content: "\F296"
-}
-
-.fa-gitter:before {
-	content: "\F426"
-}
-
-.fa-glass-martini:before {
-	content: "\F000"
-}
-
-.fa-glide:before {
-	content: "\F2A5"
-}
-
-.fa-glide-g:before {
-	content: "\F2A6"
-}
-
-.fa-globe:before {
-	content: "\F0AC"
-}
-
-.fa-gofore:before {
-	content: "\F3A7"
-}
-
-.fa-golf-ball:before {
-	content: "\F450"
-}
-
-.fa-goodreads:before {
-	content: "\F3A8"
-}
-
-.fa-goodreads-g:before {
-	content: "\F3A9"
-}
-
-.fa-google:before {
-	content: "\F1A0"
-}
-
-.fa-google-drive:before {
-	content: "\F3AA"
-}
-
-.fa-google-play:before {
-	content: "\F3AB"
-}
-
-.fa-google-plus:before {
-	content: "\F2B3"
-}
-
-.fa-google-plus-g:before {
-	content: "\F0D5"
-}
-
-.fa-google-plus-square:before {
-	content: "\F0D4"
-}
-
-.fa-google-wallet:before {
-	content: "\F1EE"
-}
-
-.fa-graduation-cap:before {
-	content: "\F19D"
-}
-
-.fa-gratipay:before {
-	content: "\F184"
-}
-
-.fa-grav:before {
-	content: "\F2D6"
-}
-
-.fa-gripfire:before {
-	content: "\F3AC"
-}
-
-.fa-grunt:before {
-	content: "\F3AD"
-}
-
-.fa-gulp:before {
-	content: "\F3AE"
-}
-
-.fa-h-square:before {
-	content: "\F0FD"
-}
-
-.fa-hacker-news:before {
-	content: "\F1D4"
-}
-
-.fa-hacker-news-square:before {
-	content: "\F3AF"
-}
-
-.fa-hand-lizard:before {
-	content: "\F258"
-}
-
-.fa-hand-paper:before {
-	content: "\F256"
-}
-
-.fa-hand-peace:before {
-	content: "\F25B"
-}
-
-.fa-hand-point-down:before {
-	content: "\F0A7"
-}
-
-.fa-hand-point-left:before {
-	content: "\F0A5"
-}
-
-.fa-hand-point-right:before {
-	content: "\F0A4"
-}
-
-.fa-hand-point-up:before {
-	content: "\F0A6"
-}
-
-.fa-hand-pointer:before {
-	content: "\F25A"
-}
-
-.fa-hand-rock:before {
-	content: "\F255"
-}
-
-.fa-hand-scissors:before {
-	content: "\F257"
-}
-
-.fa-hand-spock:before {
-	content: "\F259"
-}
-
-.fa-handshake:before {
-	content: "\F2B5"
-}
-
-.fa-hashtag:before {
-	content: "\F292"
-}
-
-.fa-hdd:before {
-	content: "\F0A0"
-}
-
-.fa-heading:before {
-	content: "\F1DC"
-}
-
-.fa-headphones:before {
-	content: "\F025"
-}
-
-.fa-heart:before {
-	content: "\F004"
-}
-
-.fa-heartbeat:before {
-	content: "\F21E"
-}
-
-.fa-hips:before {
-	content: "\F452"
-}
-
-.fa-hire-a-helper:before {
-	content: "\F3B0"
-}
-
-.fa-history:before {
-	content: "\F1DA"
-}
-
-.fa-hockey-puck:before {
-	content: "\F453"
-}
-
-.fa-home:before {
-	content: "\F015"
-}
-
-.fa-hooli:before {
-	content: "\F427"
-}
-
-.fa-hospital:before {
-	content: "\F0F8"
-}
-
-.fa-hotjar:before {
-	content: "\F3B1"
-}
-
-.fa-hourglass:before {
-	content: "\F254"
-}
-
-.fa-hourglass-end:before {
-	content: "\F253"
-}
-
-.fa-hourglass-half:before {
-	content: "\F252"
-}
-
-.fa-hourglass-start:before {
-	content: "\F251"
-}
-
-.fa-houzz:before {
-	content: "\F27C"
-}
-
-.fa-html5:before {
-	content: "\F13B"
-}
-
-.fa-hubspot:before {
-	content: "\F3B2"
-}
-
-.fa-i-cursor:before {
-	content: "\F246"
-}
-
-.fa-id-badge:before {
-	content: "\F2C1"
-}
-
-.fa-id-card:before {
-	content: "\F2C2"
-}
-
-.fa-image:before {
-	content: "\F03E"
-}
-
-.fa-images:before {
-	content: "\F302"
-}
-
-.fa-imdb:before {
-	content: "\F2D8"
-}
-
-.fa-inbox:before {
-	content: "\F01C"
-}
-
-.fa-indent:before {
-	content: "\F03C"
-}
-
-.fa-industry:before {
-	content: "\F275"
-}
-
-.fa-info:before {
-	content: "\F129"
-}
-
-.fa-info-circle:before {
-	content: "\F05A"
-}
-
-.fa-instagram:before {
-	content: "\F16D"
-}
-
-.fa-internet-explorer:before {
-	content: "\F26B"
-}
-
-.fa-ioxhost:before {
-	content: "\F208"
-}
-
-.fa-italic:before {
-	content: "\F033"
-}
-
-.fa-itunes:before {
-	content: "\F3B4"
-}
-
-.fa-itunes-note:before {
-	content: "\F3B5"
-}
-
-.fa-jenkins:before {
-	content: "\F3B6"
-}
-
-.fa-joget:before {
-	content: "\F3B7"
-}
-
-.fa-joomla:before {
-	content: "\F1AA"
-}
-
-.fa-js:before {
-	content: "\F3B8"
-}
-
-.fa-js-square:before {
-	content: "\F3B9"
-}
-
-.fa-jsfiddle:before {
-	content: "\F1CC"
-}
-
-.fa-key:before {
-	content: "\F084"
-}
-
-.fa-keyboard:before {
-	content: "\F11C"
-}
-
-.fa-keycdn:before {
-	content: "\F3BA"
-}
-
-.fa-kickstarter:before {
-	content: "\F3BB"
-}
-
-.fa-kickstarter-k:before {
-	content: "\F3BC"
-}
-
-.fa-korvue:before {
-	content: "\F42F"
-}
-
-.fa-language:before {
-	content: "\F1AB"
-}
-
-.fa-laptop:before {
-	content: "\F109"
-}
-
-.fa-laravel:before {
-	content: "\F3BD"
-}
-
-.fa-lastfm:before {
-	content: "\F202"
-}
-
-.fa-lastfm-square:before {
-	content: "\F203"
-}
-
-.fa-leaf:before {
-	content: "\F06C"
-}
-
-.fa-leanpub:before {
-	content: "\F212"
-}
-
-.fa-lemon:before {
-	content: "\F094"
-}
-
-.fa-less:before {
-	content: "\F41D"
-}
-
-.fa-level-down-alt:before {
-	content: "\F3BE"
-}
-
-.fa-level-up-alt:before {
-	content: "\F3BF"
-}
-
-.fa-life-ring:before {
-	content: "\F1CD"
-}
-
-.fa-lightbulb:before {
-	content: "\F0EB"
-}
-
-.fa-line:before {
-	content: "\F3C0"
-}
-
-.fa-link:before {
-	content: "\F0C1"
-}
-
-.fa-linkedin:before {
-	content: "\F08C"
-}
-
-.fa-linkedin-in:before {
-	content: "\F0E1"
-}
-
-.fa-linode:before {
-	content: "\F2B8"
-}
-
-.fa-linux:before {
-	content: "\F17C"
-}
-
-.fa-lira-sign:before {
-	content: "\F195"
-}
-
-.fa-list:before {
-	content: "\F03A"
-}
-
-.fa-list-alt:before {
-	content: "\F022"
-}
-
-.fa-list-ol:before {
-	content: "\F0CB"
-}
-
-.fa-list-ul:before {
-	content: "\F0CA"
-}
-
-.fa-location-arrow:before {
-	content: "\F124"
-}
-
-.fa-lock:before {
-	content: "\F023"
-}
-
-.fa-lock-open:before {
-	content: "\F3C1"
-}
-
-.fa-long-arrow-alt-down:before {
-	content: "\F309"
-}
-
-.fa-long-arrow-alt-left:before {
-	content: "\F30A"
-}
-
-.fa-long-arrow-alt-right:before {
-	content: "\F30B"
-}
-
-.fa-long-arrow-alt-up:before {
-	content: "\F30C"
-}
-
-.fa-low-vision:before {
-	content: "\F2A8"
-}
-
-.fa-lyft:before {
-	content: "\F3C3"
-}
-
-.fa-magento:before {
-	content: "\F3C4"
-}
-
-.fa-magic:before {
-	content: "\F0D0"
-}
-
-.fa-magnet:before {
-	content: "\F076"
-}
-
-.fa-male:before {
-	content: "\F183"
-}
-
-.fa-map:before {
-	content: "\F279"
-}
-
-.fa-map-marker:before {
-	content: "\F041"
-}
-
-.fa-map-marker-alt:before {
-	content: "\F3C5"
-}
-
-.fa-map-pin:before {
-	content: "\F276"
-}
-
-.fa-map-signs:before {
-	content: "\F277"
-}
-
-.fa-mars:before {
-	content: "\F222"
-}
-
-.fa-mars-double:before {
-	content: "\F227"
-}
-
-.fa-mars-stroke:before {
-	content: "\F229"
-}
-
-.fa-mars-stroke-h:before {
-	content: "\F22B"
-}
-
-.fa-mars-stroke-v:before {
-	content: "\F22A"
-}
-
-.fa-maxcdn:before {
-	content: "\F136"
-}
-
-.fa-medapps:before {
-	content: "\F3C6"
-}
-
-.fa-medium:before {
-	content: "\F23A"
-}
-
-.fa-medium-m:before {
-	content: "\F3C7"
-}
-
-.fa-medkit:before {
-	content: "\F0FA"
-}
-
-.fa-medrt:before {
-	content: "\F3C8"
-}
-
-.fa-meetup:before {
-	content: "\F2E0"
-}
-
-.fa-meh:before {
-	content: "\F11A"
-}
-
-.fa-mercury:before {
-	content: "\F223"
-}
-
-.fa-microchip:before {
-	content: "\F2DB"
-}
-
-.fa-microphone:before {
-	content: "\F130"
-}
-
-.fa-microphone-slash:before {
-	content: "\F131"
-}
-
-.fa-microsoft:before {
-	content: "\F3CA"
-}
-
-.fa-minus:before {
-	content: "\F068"
-}
-
-.fa-minus-circle:before {
-	content: "\F056"
-}
-
-.fa-minus-square:before {
-	content: "\F146"
-}
-
-.fa-mix:before {
-	content: "\F3CB"
-}
-
-.fa-mixcloud:before {
-	content: "\F289"
-}
-
-.fa-mizuni:before {
-	content: "\F3CC"
-}
-
-.fa-mobile:before {
-	content: "\F10B"
-}
-
-.fa-mobile-alt:before {
-	content: "\F3CD"
-}
-
-.fa-modx:before {
-	content: "\F285"
-}
-
-.fa-monero:before {
-	content: "\F3D0"
-}
-
-.fa-money-bill-alt:before {
-	content: "\F3D1"
-}
-
-.fa-moon:before {
-	content: "\F186"
-}
-
-.fa-motorcycle:before {
-	content: "\F21C"
-}
-
-.fa-mouse-pointer:before {
-	content: "\F245"
-}
-
-.fa-music:before {
-	content: "\F001"
-}
-
-.fa-napster:before {
-	content: "\F3D2"
-}
-
-.fa-neuter:before {
-	content: "\F22C"
-}
-
-.fa-newspaper:before {
-	content: "\F1EA"
-}
-
-.fa-nintendo-switch:before {
-	content: "\F418"
-}
-
-.fa-node:before {
-	content: "\F419"
-}
-
-.fa-node-js:before {
-	content: "\F3D3"
-}
-
-.fa-npm:before {
-	content: "\F3D4"
-}
-
-.fa-ns8:before {
-	content: "\F3D5"
-}
-
-.fa-nutritionix:before {
-	content: "\F3D6"
-}
-
-.fa-object-group:before {
-	content: "\F247"
-}
-
-.fa-object-ungroup:before {
-	content: "\F248"
-}
-
-.fa-odnoklassniki:before {
-	content: "\F263"
-}
-
-.fa-odnoklassniki-square:before {
-	content: "\F264"
-}
-
-.fa-opencart:before {
-	content: "\F23D"
-}
-
-.fa-openid:before {
-	content: "\F19B"
-}
-
-.fa-opera:before {
-	content: "\F26A"
-}
-
-.fa-optin-monster:before {
-	content: "\F23C"
-}
-
-.fa-osi:before {
-	content: "\F41A"
-}
-
-.fa-outdent:before {
-	content: "\F03B"
-}
-
-.fa-page4:before {
-	content: "\F3D7"
-}
-
-.fa-pagelines:before {
-	content: "\F18C"
-}
-
-.fa-paint-brush:before {
-	content: "\F1FC"
-}
-
-.fa-palfed:before {
-	content: "\F3D8"
-}
-
-.fa-paper-plane:before {
-	content: "\F1D8"
-}
-
-.fa-paperclip:before {
-	content: "\F0C6"
-}
-
-.fa-paragraph:before {
-	content: "\F1DD"
-}
-
-.fa-paste:before {
-	content: "\F0EA"
-}
-
-.fa-patreon:before {
-	content: "\F3D9"
-}
-
-.fa-pause:before {
-	content: "\F04C"
-}
-
-.fa-pause-circle:before {
-	content: "\F28B"
-}
-
-.fa-paw:before {
-	content: "\F1B0"
-}
-
-.fa-paypal:before {
-	content: "\F1ED"
-}
-
-.fa-pen-square:before {
-	content: "\F14B"
-}
-
-.fa-pencil-alt:before {
-	content: "\F303"
-}
-
-.fa-percent:before {
-	content: "\F295"
-}
-
-.fa-periscope:before {
-	content: "\F3DA"
-}
-
-.fa-phabricator:before {
-	content: "\F3DB"
-}
-
-.fa-phoenix-framework:before {
-	content: "\F3DC"
-}
-
-.fa-phone:before {
-	content: "\F095"
-}
-
-.fa-phone-square:before {
-	content: "\F098"
-}
-
-.fa-phone-volume:before {
-	content: "\F2A0"
-}
-
-.fa-php:before {
-	content: "\F457"
-}
-
-.fa-pied-piper:before {
-	content: "\F2AE"
-}
-
-.fa-pied-piper-alt:before {
-	content: "\F1A8"
-}
-
-.fa-pied-piper-pp:before {
-	content: "\F1A7"
-}
-
-.fa-pinterest:before {
-	content: "\F0D2"
-}
-
-.fa-pinterest-p:before {
-	content: "\F231"
-}
-
-.fa-pinterest-square:before {
-	content: "\F0D3"
-}
-
-.fa-plane:before {
-	content: "\F072"
-}
-
-.fa-play:before {
-	content: "\F04B"
-}
-
-.fa-play-circle:before {
-	content: "\F144"
-}
-
-.fa-playstation:before {
-	content: "\F3DF"
-}
-
-.fa-plug:before {
-	content: "\F1E6"
-}
-
-.fa-plus:before {
-	content: "\F067"
-}
-
-.fa-plus-circle:before {
-	content: "\F055"
-}
-
-.fa-plus-square:before {
-	content: "\F0FE"
-}
-
-.fa-podcast:before {
-	content: "\F2CE"
-}
-
-.fa-pound-sign:before {
-	content: "\F154"
-}
-
-.fa-power-off:before {
-	content: "\F011"
-}
-
-.fa-print:before {
-	content: "\F02F"
-}
-
-.fa-product-hunt:before {
-	content: "\F288"
-}
-
-.fa-pushed:before {
-	content: "\F3E1"
-}
-
-.fa-puzzle-piece:before {
-	content: "\F12E"
-}
-
-.fa-python:before {
-	content: "\F3E2"
-}
-
-.fa-qq:before {
-	content: "\F1D6"
-}
-
-.fa-qrcode:before {
-	content: "\F029"
-}
-
-.fa-question:before {
-	content: "\F128"
-}
-
-.fa-question-circle:before {
-	content: "\F059"
-}
-
-.fa-quidditch:before {
-	content: "\F458"
-}
-
-.fa-quinscape:before {
-	content: "\F459"
-}
-
-.fa-quora:before {
-	content: "\F2C4"
-}
-
-.fa-quote-left:before {
-	content: "\F10D"
-}
-
-.fa-quote-right:before {
-	content: "\F10E"
-}
-
-.fa-random:before {
-	content: "\F074"
-}
-
-.fa-ravelry:before {
-	content: "\F2D9"
-}
-
-.fa-react:before {
-	content: "\F41B"
-}
-
-.fa-rebel:before {
-	content: "\F1D0"
-}
-
-.fa-recycle:before {
-	content: "\F1B8"
-}
-
-.fa-red-river:before {
-	content: "\F3E3"
-}
-
-.fa-reddit:before {
-	content: "\F1A1"
-}
-
-.fa-reddit-alien:before {
-	content: "\F281"
-}
-
-.fa-reddit-square:before {
-	content: "\F1A2"
-}
-
-.fa-redo:before {
-	content: "\F01E"
-}
-
-.fa-redo-alt:before {
-	content: "\F2F9"
-}
-
-.fa-registered:before {
-	content: "\F25D"
-}
-
-.fa-rendact:before {
-	content: "\F3E4"
-}
-
-.fa-renren:before {
-	content: "\F18B"
-}
-
-.fa-reply:before {
-	content: "\F3E5"
-}
-
-.fa-reply-all:before {
-	content: "\F122"
-}
-
-.fa-replyd:before {
-	content: "\F3E6"
-}
-
-.fa-resolving:before {
-	content: "\F3E7"
-}
-
-.fa-retweet:before {
-	content: "\F079"
-}
-
-.fa-road:before {
-	content: "\F018"
-}
-
-.fa-rocket:before {
-	content: "\F135"
-}
-
-.fa-rocketchat:before {
-	content: "\F3E8"
-}
-
-.fa-rockrms:before {
-	content: "\F3E9"
-}
-
-.fa-rss:before {
-	content: "\F09E"
-}
-
-.fa-rss-square:before {
-	content: "\F143"
-}
-
-.fa-ruble-sign:before {
-	content: "\F158"
-}
-
-.fa-rupee-sign:before {
-	content: "\F156"
-}
-
-.fa-safari:before {
-	content: "\F267"
-}
-
-.fa-sass:before {
-	content: "\F41E"
-}
-
-.fa-save:before {
-	content: "\F0C7"
-}
-
-.fa-schlix:before {
-	content: "\F3EA"
-}
-
-.fa-scribd:before {
-	content: "\F28A"
-}
-
-.fa-search:before {
-	content: "\F002"
-}
-
-.fa-search-minus:before {
-	content: "\F010"
-}
-
-.fa-search-plus:before {
-	content: "\F00E"
-}
-
-.fa-searchengin:before {
-	content: "\F3EB"
-}
-
-.fa-sellcast:before {
-	content: "\F2DA"
-}
-
-.fa-sellsy:before {
-	content: "\F213"
-}
-
-.fa-server:before {
-	content: "\F233"
-}
-
-.fa-servicestack:before {
-	content: "\F3EC"
-}
-
-.fa-share:before {
-	content: "\F064"
-}
-
-.fa-share-alt:before {
-	content: "\F1E0"
-}
-
-.fa-share-alt-square:before {
-	content: "\F1E1"
-}
-
-.fa-share-square:before {
-	content: "\F14D"
-}
-
-.fa-shekel-sign:before {
-	content: "\F20B"
-}
-
-.fa-shield-alt:before {
-	content: "\F3ED"
-}
-
-.fa-ship:before {
-	content: "\F21A"
-}
-
-.fa-shirtsinbulk:before {
-	content: "\F214"
-}
-
-.fa-shopping-bag:before {
-	content: "\F290"
-}
-
-.fa-shopping-basket:before {
-	content: "\F291"
-}
-
-.fa-shopping-cart:before {
-	content: "\F07A"
-}
-
-.fa-shower:before {
-	content: "\F2CC"
-}
-
-.fa-sign-in-alt:before {
-	content: "\F2F6"
-}
-
-.fa-sign-language:before {
-	content: "\F2A7"
-}
-
-.fa-sign-out-alt:before {
-	content: "\F2F5"
-}
-
-.fa-signal:before {
-	content: "\F012"
-}
-
-.fa-simplybuilt:before {
-	content: "\F215"
-}
-
-.fa-sistrix:before {
-	content: "\F3EE"
-}
-
-.fa-sitemap:before {
-	content: "\F0E8"
-}
-
-.fa-skyatlas:before {
-	content: "\F216"
-}
-
-.fa-skype:before {
-	content: "\F17E"
-}
-
-.fa-slack:before {
-	content: "\F198"
-}
-
-.fa-slack-hash:before {
-	content: "\F3EF"
-}
-
-.fa-sliders-h:before {
-	content: "\F1DE"
-}
-
-.fa-slideshare:before {
-	content: "\F1E7"
-}
-
-.fa-smile:before {
-	content: "\F118"
-}
-
-.fa-snapchat:before {
-	content: "\F2AB"
-}
-
-.fa-snapchat-ghost:before {
-	content: "\F2AC"
-}
-
-.fa-snapchat-square:before {
-	content: "\F2AD"
-}
-
-.fa-snowflake:before {
-	content: "\F2DC"
-}
-
-.fa-sort:before {
-	content: "\F0DC"
-}
-
-.fa-sort-alpha-down:before {
-	content: "\F15D"
-}
-
-.fa-sort-alpha-up:before {
-	content: "\F15E"
-}
-
-.fa-sort-amount-down:before {
-	content: "\F160"
-}
-
-.fa-sort-amount-up:before {
-	content: "\F161"
-}
-
-.fa-sort-down:before {
-	content: "\F0DD"
-}
-
-.fa-sort-numeric-down:before {
-	content: "\F162"
-}
-
-.fa-sort-numeric-up:before {
-	content: "\F163"
-}
-
-.fa-sort-up:before {
-	content: "\F0DE"
-}
-
-.fa-soundcloud:before {
-	content: "\F1BE"
-}
-
-.fa-space-shuttle:before {
-	content: "\F197"
-}
-
-.fa-speakap:before {
-	content: "\F3F3"
-}
-
-.fa-spinner:before {
-	content: "\F110"
-}
-
-.fa-spotify:before {
-	content: "\F1BC"
-}
-
-.fa-square:before {
-	content: "\F0C8"
-}
-
-.fa-square-full:before {
-	content: "\F45C"
-}
-
-.fa-stack-exchange:before {
-	content: "\F18D"
-}
-
-.fa-stack-overflow:before {
-	content: "\F16C"
-}
-
-.fa-star:before {
-	content: "\F005"
-}
-
-.fa-star-half:before {
-	content: "\F089"
-}
-
-.fa-staylinked:before {
-	content: "\F3F5"
-}
-
-.fa-steam:before {
-	content: "\F1B6"
-}
-
-.fa-steam-square:before {
-	content: "\F1B7"
-}
-
-.fa-steam-symbol:before {
-	content: "\F3F6"
-}
-
-.fa-step-backward:before {
-	content: "\F048"
-}
-
-.fa-step-forward:before {
-	content: "\F051"
-}
-
-.fa-stethoscope:before {
-	content: "\F0F1"
-}
-
-.fa-sticker-mule:before {
-	content: "\F3F7"
-}
-
-.fa-sticky-note:before {
-	content: "\F249"
-}
-
-.fa-stop:before {
-	content: "\F04D"
-}
-
-.fa-stop-circle:before {
-	content: "\F28D"
-}
-
-.fa-stopwatch:before {
-	content: "\F2F2"
-}
-
-.fa-strava:before {
-	content: "\F428"
-}
-
-.fa-street-view:before {
-	content: "\F21D"
-}
-
-.fa-strikethrough:before {
-	content: "\F0CC"
-}
-
-.fa-stripe:before {
-	content: "\F429"
-}
-
-.fa-stripe-s:before {
-	content: "\F42A"
-}
-
-.fa-studiovinari:before {
-	content: "\F3F8"
-}
-
-.fa-stumbleupon:before {
-	content: "\F1A4"
-}
-
-.fa-stumbleupon-circle:before {
-	content: "\F1A3"
-}
-
-.fa-subscript:before {
-	content: "\F12C"
-}
-
-.fa-subway:before {
-	content: "\F239"
-}
-
-.fa-suitcase:before {
-	content: "\F0F2"
-}
-
-.fa-sun:before {
-	content: "\F185"
-}
-
-.fa-superpowers:before {
-	content: "\F2DD"
-}
-
-.fa-superscript:before {
-	content: "\F12B"
-}
-
-.fa-supple:before {
-	content: "\F3F9"
-}
-
-.fa-sync:before {
-	content: "\F021"
-}
-
-.fa-sync-alt:before {
-	content: "\F2F1"
-}
-
-.fa-table:before {
-	content: "\F0CE"
-}
-
-.fa-table-tennis:before {
-	content: "\F45D"
-}
-
-.fa-tablet:before {
-	content: "\F10A"
-}
-
-.fa-tablet-alt:before {
-	content: "\F3FA"
-}
-
-.fa-tachometer-alt:before {
-	content: "\F3FD"
-}
-
-.fa-tag:before {
-	content: "\F02B"
-}
-
-.fa-tags:before {
-	content: "\F02C"
-}
-
-.fa-tasks:before {
-	content: "\F0AE"
-}
-
-.fa-taxi:before {
-	content: "\F1BA"
-}
-
-.fa-telegram:before {
-	content: "\F2C6"
-}
-
-.fa-telegram-plane:before {
-	content: "\F3FE"
-}
-
-.fa-tencent-weibo:before {
-	content: "\F1D5"
-}
-
-.fa-terminal:before {
-	content: "\F120"
-}
-
-.fa-text-height:before {
-	content: "\F034"
-}
-
-.fa-text-width:before {
-	content: "\F035"
-}
-
-.fa-th:before {
-	content: "\F00A"
-}
-
-.fa-th-large:before {
-	content: "\F009"
-}
-
-.fa-th-list:before {
-	content: "\F00B"
-}
-
-.fa-themeisle:before {
-	content: "\F2B2"
-}
-
-.fa-thermometer-empty:before {
-	content: "\F2CB"
-}
-
-.fa-thermometer-full:before {
-	content: "\F2C7"
-}
-
-.fa-thermometer-half:before {
-	content: "\F2C9"
-}
-
-.fa-thermometer-quarter:before {
-	content: "\F2CA"
-}
-
-.fa-thermometer-three-quarters:before {
-	content: "\F2C8"
-}
-
-.fa-thumbs-down:before {
-	content: "\F165"
-}
-
-.fa-thumbs-up:before {
-	content: "\F164"
-}
-
-.fa-thumbtack:before {
-	content: "\F08D"
-}
-
-.fa-ticket-alt:before {
-	content: "\F3FF"
-}
-
-.fa-times:before {
-	content: "\F00D"
-}
-
-.fa-times-circle:before {
-	content: "\F057"
-}
-
-.fa-tint:before {
-	content: "\F043"
-}
-
-.fa-toggle-off:before {
-	content: "\F204"
-}
-
-.fa-toggle-on:before {
-	content: "\F205"
-}
-
-.fa-trademark:before {
-	content: "\F25C"
-}
-
-.fa-train:before {
-	content: "\F238"
-}
-
-.fa-transgender:before {
-	content: "\F224"
-}
-
-.fa-transgender-alt:before {
-	content: "\F225"
-}
-
-.fa-trash:before {
-	content: "\F1F8"
-}
-
-.fa-trash-alt:before {
-	content: "\F2ED"
-}
-
-.fa-tree:before {
-	content: "\F1BB"
-}
-
-.fa-trello:before {
-	content: "\F181"
-}
-
-.fa-tripadvisor:before {
-	content: "\F262"
-}
-
-.fa-trophy:before {
-	content: "\F091"
-}
-
-.fa-truck:before {
-	content: "\F0D1"
-}
-
-.fa-tty:before {
-	content: "\F1E4"
-}
-
-.fa-tumblr:before {
-	content: "\F173"
-}
-
-.fa-tumblr-square:before {
-	content: "\F174"
-}
-
-.fa-tv:before {
-	content: "\F26C"
-}
-
-.fa-twitch:before {
-	content: "\F1E8"
-}
-
-.fa-twitter:before {
-	content: "\F099"
-}
-
-.fa-twitter-square:before {
-	content: "\F081"
-}
-
-.fa-typo3:before {
-	content: "\F42B"
-}
-
-.fa-uber:before {
-	content: "\F402"
-}
-
-.fa-uikit:before {
-	content: "\F403"
-}
-
-.fa-umbrella:before {
-	content: "\F0E9"
-}
-
-.fa-underline:before {
-	content: "\F0CD"
-}
-
-.fa-undo:before {
-	content: "\F0E2"
-}
-
-.fa-undo-alt:before {
-	content: "\F2EA"
-}
-
-.fa-uniregistry:before {
-	content: "\F404"
-}
-
-.fa-universal-access:before {
-	content: "\F29A"
-}
-
-.fa-university:before {
-	content: "\F19C"
-}
-
-.fa-unlink:before {
-	content: "\F127"
-}
-
-.fa-unlock:before {
-	content: "\F09C"
-}
-
-.fa-unlock-alt:before {
-	content: "\F13E"
-}
-
-.fa-untappd:before {
-	content: "\F405"
-}
-
-.fa-upload:before {
-	content: "\F093"
-}
-
-.fa-usb:before {
-	content: "\F287"
-}
-
-.fa-user:before {
-	content: "\F007"
-}
-
-.fa-user-circle:before {
-	content: "\F2BD"
-}
-
-.fa-user-md:before {
-	content: "\F0F0"
-}
-
-.fa-user-plus:before {
-	content: "\F234"
-}
-
-.fa-user-secret:before {
-	content: "\F21B"
-}
-
-.fa-user-times:before {
-	content: "\F235"
-}
-
-.fa-users:before {
-	content: "\F0C0"
-}
-
-.fa-ussunnah:before {
-	content: "\F407"
-}
-
-.fa-utensil-spoon:before {
-	content: "\F2E5"
-}
-
-.fa-utensils:before {
-	content: "\F2E7"
-}
-
-.fa-vaadin:before {
-	content: "\F408"
-}
-
-.fa-venus:before {
-	content: "\F221"
-}
-
-.fa-venus-double:before {
-	content: "\F226"
-}
-
-.fa-venus-mars:before {
-	content: "\F228"
-}
-
-.fa-viacoin:before {
-	content: "\F237"
-}
-
-.fa-viadeo:before {
-	content: "\F2A9"
-}
-
-.fa-viadeo-square:before {
-	content: "\F2AA"
-}
-
-.fa-viber:before {
-	content: "\F409"
-}
-
-.fa-video:before {
-	content: "\F03D"
-}
-
-.fa-vimeo:before {
-	content: "\F40A"
-}
-
-.fa-vimeo-square:before {
-	content: "\F194"
-}
-
-.fa-vimeo-v:before {
-	content: "\F27D"
-}
-
-.fa-vine:before {
-	content: "\F1CA"
-}
-
-.fa-vk:before {
-	content: "\F189"
-}
-
-.fa-vnv:before {
-	content: "\F40B"
-}
-
-.fa-volleyball-ball:before {
-	content: "\F45F"
-}
-
-.fa-volume-down:before {
-	content: "\F027"
-}
-
-.fa-volume-off:before {
-	content: "\F026"
-}
-
-.fa-volume-up:before {
-	content: "\F028"
-}
-
-.fa-vuejs:before {
-	content: "\F41F"
-}
-
-.fa-weibo:before {
-	content: "\F18A"
-}
-
-.fa-weixin:before {
-	content: "\F1D7"
-}
-
-.fa-whatsapp:before {
-	content: "\F232"
-}
-
-.fa-whatsapp-square:before {
-	content: "\F40C"
-}
-
-.fa-wheelchair:before {
-	content: "\F193"
-}
-
-.fa-whmcs:before {
-	content: "\F40D"
-}
-
-.fa-wifi:before {
-	content: "\F1EB"
-}
-
-.fa-wikipedia-w:before {
-	content: "\F266"
-}
-
-.fa-window-close:before {
-	content: "\F410"
-}
-
-.fa-window-maximize:before {
-	content: "\F2D0"
-}
-
-.fa-window-minimize:before {
-	content: "\F2D1"
-}
-
-.fa-window-restore:before {
-	content: "\F2D2"
-}
-
-.fa-windows:before {
-	content: "\F17A"
-}
-
-.fa-won-sign:before {
-	content: "\F159"
-}
-
-.fa-wordpress:before {
-	content: "\F19A"
-}
-
-.fa-wordpress-simple:before {
-	content: "\F411"
-}
-
-.fa-wpbeginner:before {
-	content: "\F297"
-}
-
-.fa-wpexplorer:before {
-	content: "\F2DE"
-}
-
-.fa-wpforms:before {
-	content: "\F298"
-}
-
-.fa-wrench:before {
-	content: "\F0AD"
-}
-
-.fa-xbox:before {
-	content: "\F412"
-}
-
-.fa-xing:before {
-	content: "\F168"
-}
-
-.fa-xing-square:before {
-	content: "\F169"
-}
-
-.fa-y-combinator:before {
-	content: "\F23B"
-}
-
-.fa-yahoo:before {
-	content: "\F19E"
-}
-
-.fa-yandex:before {
-	content: "\F413"
-}
-
-.fa-yandex-international:before {
-	content: "\F414"
-}
-
-.fa-yelp:before {
-	content: "\F1E9"
-}
-
-.fa-yen-sign:before {
-	content: "\F157"
-}
-
-.fa-yoast:before {
-	content: "\F2B1"
-}
-
-.fa-youtube:before {
-	content: "\F167"
-}
-
-.fa-youtube-square:before {
-	content: "\F431"
-}
-
-.sr-only {
-	border: 0;
-	clip: rect(0, 0, 0, 0);
-	height: 1px;
-	margin: -1px;
-	overflow: hidden;
-	padding: 0;
-	position: absolute;
-	width: 1px
-}
-
-.sr-only-focusable:active,
-.sr-only-focusable:focus {
-	clip: auto;
-	height: auto;
-	margin: 0;
-	overflow: visible;
-	position: static;
-	width: auto
-}
-
-@font-face {
-	font-family: Font Awesome\ 5 Brands;
-	font-style: normal;
-	font-weight: 400;
-	src: url(fa-brands-400.eot);
-	src: url(fa-brands-400.eot?#iefix) format("embedded-opentype"), url(fa-brands-400.woff2) format("woff2"), url(fa-brands-400.woff) format("woff"), url(fa-brands-400.ttf) format("truetype"), url(fa-brands-400.svg#fontawesome) format("svg")
-}
-
-.fab {
-	font-family: Font Awesome\ 5 Brands
-}
-
-@font-face {
-	font-family: Font Awesome\ 5 Free;
-	font-style: normal;
-	font-weight: 400;
-	src: url(fa-regular-400.eot);
-	src: url(fa-regular-400.eot?#iefix) format("embedded-opentype"), url(fa-regular-400.woff2) format("woff2"), url(fa-regular-400.woff) format("woff"), url(fa-regular-400.ttf) format("truetype"), url(fa-regular-400.svg#fontawesome) format("svg")
-}
-
-.far {
-	font-weight: 400
-}
-
-@font-face {
-	font-family: Font Awesome\ 5 Free;
-	font-style: normal;
-	font-weight: 900;
-	src: url(fa-solid-900.eot);
-	src: url(fa-solid-900.eot?#iefix) format("embedded-opentype"), url(fa-solid-900.woff2) format("woff2"), url(fa-solid-900.woff) format("woff"), url(fa-solid-900.ttf) format("truetype"), url(fa-solid-900.svg#fontawesome) format("svg")
-}
-
-.fa,
-.far,
-.fas {
-
-}
-
-.fa,
-.fas {
-	font-weight: 900
-}
+ .fa,
+ .fab,
+ .fal,
+ .far,
+ .fas {
+ 	-moz-osx-font-smoothing: grayscale;
+ 	-webkit-font-smoothing: antialiased;
+ 	display: inline-block;
+ 	font-style: normal;
+ 	font-variant: normal;
+ 	text-rendering: auto;
+ 	line-height: 1
+ }
+
+ .fa-lg {
+ 	font-size: 1.33333333em;
+ 	line-height: .75em;
+ 	vertical-align: -.0667em
+ }
+
+ .fa-xs {
+ 	font-size: .75em
+ }
+
+ .fa-sm {
+ 	font-size: .875em
+ }
+
+ .fa-1x {
+ 	font-size: 1em
+ }
+
+ .fa-2x {
+ 	font-size: 2em
+ }
+
+ .fa-3x {
+ 	font-size: 3em
+ }
+
+ .fa-4x {
+ 	font-size: 4em
+ }
+
+ .fa-5x {
+ 	font-size: 5em
+ }
+
+ .fa-6x {
+ 	font-size: 6em
+ }
+
+ .fa-7x {
+ 	font-size: 7em
+ }
+
+ .fa-8x {
+ 	font-size: 8em
+ }
+
+ .fa-9x {
+ 	font-size: 9em
+ }
+
+ .fa-10x {
+ 	font-size: 10em
+ }
+
+ .fa-fw {
+ 	text-align: center;
+ 	width: 1.25em
+ }
+
+ .fa-ul {
+ 	list-style-type: none;
+ 	margin-left: 2em * 5/4;
+ 	padding-left: 0
+ }
+
+ .fa-ul>li {
+ 	position: relative
+ }
+
+ .fa-li {
+ 	left: -2em;
+ 	position: absolute;
+ 	text-align: center;
+ 	width: 2em;
+ 	line-height: inherit
+ }
+
+ .fa-border {
+ 	border-radius: .1em;
+ 	border: .08em solid #eee;
+ 	padding: .2em .25em .15em
+ }
+
+ .fa-pull-left {
+ 	float: left
+ }
+
+ .fa-pull-right {
+ 	float: right
+ }
+
+ .fa.fa-pull-left,
+ .fab.fa-pull-left,
+ .fal.fa-pull-left,
+ .far.fa-pull-left,
+ .fas.fa-pull-left {
+ 	margin-right: .3em
+ }
+
+ .fa.fa-pull-right,
+ .fab.fa-pull-right,
+ .fal.fa-pull-right,
+ .far.fa-pull-right,
+ .fas.fa-pull-right {
+ 	margin-left: .3em
+ }
+
+ .fa-spin {
+ 	-webkit-animation: fa-spin 2s infinite linear;
+ 	animation: fa-spin 2s infinite linear
+ }
+
+ .fa-pulse {
+ 	-webkit-animation: fa-spin 1s infinite steps(8);
+ 	animation: fa-spin 1s infinite steps(8)
+ }
+
+ @-webkit-keyframes fa-spin {
+ 	0% {
+ 		-webkit-transform: rotate(0deg);
+ 		transform: rotate(0deg)
+ 	}
+ 	to {
+ 		-webkit-transform: rotate(1turn);
+ 		transform: rotate(1turn)
+ 	}
+ }
+
+ @keyframes fa-spin {
+ 	0% {
+ 		-webkit-transform: rotate(0deg);
+ 		transform: rotate(0deg)
+ 	}
+ 	to {
+ 		-webkit-transform: rotate(1turn);
+ 		transform: rotate(1turn)
+ 	}
+ }
+
+ .fa-rotate-90 {
+ 	-ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=1)";
+ 	-webkit-transform: rotate(90deg);
+ 	transform: rotate(90deg)
+ }
+
+ .fa-rotate-180 {
+ 	-ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=2)";
+ 	-webkit-transform: rotate(180deg);
+ 	transform: rotate(180deg)
+ }
+
+ .fa-rotate-270 {
+ 	-ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=3)";
+ 	-webkit-transform: rotate(270deg);
+ 	transform: rotate(270deg)
+ }
+
+ .fa-flip-horizontal {
+ 	-ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=0, mirror=1)";
+ 	-webkit-transform: scaleX(-1);
+ 	transform: scaleX(-1)
+ }
+
+ .fa-flip-vertical {
+ 	-webkit-transform: scaleY(-1);
+ 	transform: scaleY(-1)
+ }
+
+ .fa-flip-horizontal.fa-flip-vertical,
+ .fa-flip-vertical {
+ 	-ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=2, mirror=1)"
+ }
+
+ .fa-flip-horizontal.fa-flip-vertical {
+ 	-webkit-transform: scale(-1);
+ 	transform: scale(-1)
+ }
+
+ :root .fa-flip-horizontal,
+ :root .fa-flip-vertical,
+ :root .fa-rotate-90,
+ :root .fa-rotate-180,
+ :root .fa-rotate-270 {
+ 	-webkit-filter: none;
+ 	filter: none
+ }
+
+ .fa-stack {
+ 	display: inline-block;
+ 	height: 2em;
+ 	line-height: 2em;
+ 	position: relative;
+ 	vertical-align: middle;
+ 	width: 2em
+ }
+
+ .fa-stack-1x,
+ .fa-stack-2x {
+ 	left: 0;
+ 	position: absolute;
+ 	text-align: center;
+ 	width: 100%
+ }
+
+ .fa-stack-1x {
+ 	line-height: inherit
+ }
+
+ .fa-stack-2x {
+ 	font-size: 2em
+ }
+
+ .fa-inverse {
+ 	color: #fff
+ }
+
+ .fa-500px:before {
+ 	content: "\F26E"
+ }
+
+ .fa-accessible-icon:before {
+ 	content: "\F368"
+ }
+
+ .fa-accusoft:before {
+ 	content: "\F369"
+ }
+
+ .fa-address-book:before {
+ 	content: "\F2B9"
+ }
+
+ .fa-address-card:before {
+ 	content: "\F2BB"
+ }
+
+ .fa-adjust:before {
+ 	content: "\F042"
+ }
+
+ .fa-adn:before {
+ 	content: "\F170"
+ }
+
+ .fa-adversal:before {
+ 	content: "\F36A"
+ }
+
+ .fa-affiliatetheme:before {
+ 	content: "\F36B"
+ }
+
+ .fa-algolia:before {
+ 	content: "\F36C"
+ }
+
+ .fa-align-center:before {
+ 	content: "\F037"
+ }
+
+ .fa-align-justify:before {
+ 	content: "\F039"
+ }
+
+ .fa-align-left:before {
+ 	content: "\F036"
+ }
+
+ .fa-align-right:before {
+ 	content: "\F038"
+ }
+
+ .fa-amazon:before {
+ 	content: "\F270"
+ }
+
+ .fa-amazon-pay:before {
+ 	content: "\F42C"
+ }
+
+ .fa-ambulance:before {
+ 	content: "\F0F9"
+ }
+
+ .fa-american-sign-language-interpreting:before {
+ 	content: "\F2A3"
+ }
+
+ .fa-amilia:before {
+ 	content: "\F36D"
+ }
+
+ .fa-anchor:before {
+ 	content: "\F13D"
+ }
+
+ .fa-android:before {
+ 	content: "\F17B"
+ }
+
+ .fa-angellist:before {
+ 	content: "\F209"
+ }
+
+ .fa-angle-double-down:before {
+ 	content: "\F103"
+ }
+
+ .fa-angle-double-left:before {
+ 	content: "\F100"
+ }
+
+ .fa-angle-double-right:before {
+ 	content: "\F101"
+ }
+
+ .fa-angle-double-up:before {
+ 	content: "\F102"
+ }
+
+ .fa-angle-down:before {
+ 	content: "\F107"
+ }
+
+ .fa-angle-left:before {
+ 	content: "\F104"
+ }
+
+ .fa-angle-right:before {
+ 	content: "\F105"
+ }
+
+ .fa-angle-up:before {
+ 	content: "\F106"
+ }
+
+ .fa-angrycreative:before {
+ 	content: "\F36E"
+ }
+
+ .fa-angular:before {
+ 	content: "\F420"
+ }
+
+ .fa-app-store:before {
+ 	content: "\F36F"
+ }
+
+ .fa-app-store-ios:before {
+ 	content: "\F370"
+ }
+
+ .fa-apper:before {
+ 	content: "\F371"
+ }
+
+ .fa-apple:before {
+ 	content: "\F179"
+ }
+
+ .fa-apple-pay:before {
+ 	content: "\F415"
+ }
+
+ .fa-archive:before {
+ 	content: "\F187"
+ }
+
+ .fa-arrow-alt-circle-down:before {
+ 	content: "\F358"
+ }
+
+ .fa-arrow-alt-circle-left:before {
+ 	content: "\F359"
+ }
+
+ .fa-arrow-alt-circle-right:before {
+ 	content: "\F35A"
+ }
+
+ .fa-arrow-alt-circle-up:before {
+ 	content: "\F35B"
+ }
+
+ .fa-arrow-circle-down:before {
+ 	content: "\F0AB"
+ }
+
+ .fa-arrow-circle-left:before {
+ 	content: "\F0A8"
+ }
+
+ .fa-arrow-circle-right:before {
+ 	content: "\F0A9"
+ }
+
+ .fa-arrow-circle-up:before {
+ 	content: "\F0AA"
+ }
+
+ .fa-arrow-down:before {
+ 	content: "\F063"
+ }
+
+ .fa-arrow-left:before {
+ 	content: "\F060"
+ }
+
+ .fa-arrow-right:before {
+ 	content: "\F061"
+ }
+
+ .fa-arrow-up:before {
+ 	content: "\F062"
+ }
+
+ .fa-arrows-alt:before {
+ 	content: "\F0B2"
+ }
+
+ .fa-arrows-alt-h:before {
+ 	content: "\F337"
+ }
+
+ .fa-arrows-alt-v:before {
+ 	content: "\F338"
+ }
+
+ .fa-assistive-listening-systems:before {
+ 	content: "\F2A2"
+ }
+
+ .fa-asterisk:before {
+ 	content: "\F069"
+ }
+
+ .fa-asymmetrik:before {
+ 	content: "\F372"
+ }
+
+ .fa-at:before {
+ 	content: "\F1FA"
+ }
+
+ .fa-audible:before {
+ 	content: "\F373"
+ }
+
+ .fa-audio-description:before {
+ 	content: "\F29E"
+ }
+
+ .fa-autoprefixer:before {
+ 	content: "\F41C"
+ }
+
+ .fa-avianex:before {
+ 	content: "\F374"
+ }
+
+ .fa-aviato:before {
+ 	content: "\F421"
+ }
+
+ .fa-aws:before {
+ 	content: "\F375"
+ }
+
+ .fa-backward:before {
+ 	content: "\F04A"
+ }
+
+ .fa-balance-scale:before {
+ 	content: "\F24E"
+ }
+
+ .fa-ban:before {
+ 	content: "\F05E"
+ }
+
+ .fa-bandcamp:before {
+ 	content: "\F2D5"
+ }
+
+ .fa-barcode:before {
+ 	content: "\F02A"
+ }
+
+ .fa-bars:before {
+ 	content: "\F0C9"
+ }
+
+ .fa-baseball-ball:before {
+ 	content: "\F433"
+ }
+
+ .fa-basketball-ball:before {
+ 	content: "\F434"
+ }
+
+ .fa-bath:before {
+ 	content: "\F2CD"
+ }
+
+ .fa-battery-empty:before {
+ 	content: "\F244"
+ }
+
+ .fa-battery-full:before {
+ 	content: "\F240"
+ }
+
+ .fa-battery-half:before {
+ 	content: "\F242"
+ }
+
+ .fa-battery-quarter:before {
+ 	content: "\F243"
+ }
+
+ .fa-battery-three-quarters:before {
+ 	content: "\F241"
+ }
+
+ .fa-bed:before {
+ 	content: "\F236"
+ }
+
+ .fa-beer:before {
+ 	content: "\F0FC"
+ }
+
+ .fa-behance:before {
+ 	content: "\F1B4"
+ }
+
+ .fa-behance-square:before {
+ 	content: "\F1B5"
+ }
+
+ .fa-bell:before {
+ 	content: "\F0F3"
+ }
+
+ .fa-bell-slash:before {
+ 	content: "\F1F6"
+ }
+
+ .fa-bicycle:before {
+ 	content: "\F206"
+ }
+
+ .fa-bimobject:before {
+ 	content: "\F378"
+ }
+
+ .fa-binoculars:before {
+ 	content: "\F1E5"
+ }
+
+ .fa-birthday-cake:before {
+ 	content: "\F1FD"
+ }
+
+ .fa-bitbucket:before {
+ 	content: "\F171"
+ }
+
+ .fa-bitcoin:before {
+ 	content: "\F379"
+ }
+
+ .fa-bity:before {
+ 	content: "\F37A"
+ }
+
+ .fa-black-tie:before {
+ 	content: "\F27E"
+ }
+
+ .fa-blackberry:before {
+ 	content: "\F37B"
+ }
+
+ .fa-blind:before {
+ 	content: "\F29D"
+ }
+
+ .fa-blogger:before {
+ 	content: "\F37C"
+ }
+
+ .fa-blogger-b:before {
+ 	content: "\F37D"
+ }
+
+ .fa-bluetooth:before {
+ 	content: "\F293"
+ }
+
+ .fa-bluetooth-b:before {
+ 	content: "\F294"
+ }
+
+ .fa-bold:before {
+ 	content: "\F032"
+ }
+
+ .fa-bolt:before {
+ 	content: "\F0E7"
+ }
+
+ .fa-bomb:before {
+ 	content: "\F1E2"
+ }
+
+ .fa-book:before {
+ 	content: "\F02D"
+ }
+
+ .fa-bookmark:before {
+ 	content: "\F02E"
+ }
+
+ .fa-bowling-ball:before {
+ 	content: "\F436"
+ }
+
+ .fa-braille:before {
+ 	content: "\F2A1"
+ }
+
+ .fa-briefcase:before {
+ 	content: "\F0B1"
+ }
+
+ .fa-btc:before {
+ 	content: "\F15A"
+ }
+
+ .fa-bug:before {
+ 	content: "\F188"
+ }
+
+ .fa-building:before {
+ 	content: "\F1AD"
+ }
+
+ .fa-bullhorn:before {
+ 	content: "\F0A1"
+ }
+
+ .fa-bullseye:before {
+ 	content: "\F140"
+ }
+
+ .fa-buromobelexperte:before {
+ 	content: "\F37F"
+ }
+
+ .fa-bus:before {
+ 	content: "\F207"
+ }
+
+ .fa-buysellads:before {
+ 	content: "\F20D"
+ }
+
+ .fa-calculator:before {
+ 	content: "\F1EC"
+ }
+
+ .fa-calendar:before {
+ 	content: "\F133"
+ }
+
+ .fa-calendar-alt:before {
+ 	content: "\F073"
+ }
+
+ .fa-calendar-check:before {
+ 	content: "\F274"
+ }
+
+ .fa-calendar-minus:before {
+ 	content: "\F272"
+ }
+
+ .fa-calendar-plus:before {
+ 	content: "\F271"
+ }
+
+ .fa-calendar-times:before {
+ 	content: "\F273"
+ }
+
+ .fa-camera:before {
+ 	content: "\F030"
+ }
+
+ .fa-camera-retro:before {
+ 	content: "\F083"
+ }
+
+ .fa-car:before {
+ 	content: "\F1B9"
+ }
+
+ .fa-caret-down:before {
+ 	content: "\F0D7"
+ }
+
+ .fa-caret-left:before {
+ 	content: "\F0D9"
+ }
+
+ .fa-caret-right:before {
+ 	content: "\F0DA"
+ }
+
+ .fa-caret-square-down:before {
+ 	content: "\F150"
+ }
+
+ .fa-caret-square-left:before {
+ 	content: "\F191"
+ }
+
+ .fa-caret-square-right:before {
+ 	content: "\F152"
+ }
+
+ .fa-caret-square-up:before {
+ 	content: "\F151"
+ }
+
+ .fa-caret-up:before {
+ 	content: "\F0D8"
+ }
+
+ .fa-cart-arrow-down:before {
+ 	content: "\F218"
+ }
+
+ .fa-cart-plus:before {
+ 	content: "\F217"
+ }
+
+ .fa-cc-amazon-pay:before {
+ 	content: "\F42D"
+ }
+
+ .fa-cc-amex:before {
+ 	content: "\F1F3"
+ }
+
+ .fa-cc-apple-pay:before {
+ 	content: "\F416"
+ }
+
+ .fa-cc-diners-club:before {
+ 	content: "\F24C"
+ }
+
+ .fa-cc-discover:before {
+ 	content: "\F1F2"
+ }
+
+ .fa-cc-jcb:before {
+ 	content: "\F24B"
+ }
+
+ .fa-cc-mastercard:before {
+ 	content: "\F1F1"
+ }
+
+ .fa-cc-paypal:before {
+ 	content: "\F1F4"
+ }
+
+ .fa-cc-stripe:before {
+ 	content: "\F1F5"
+ }
+
+ .fa-cc-visa:before {
+ 	content: "\F1F0"
+ }
+
+ .fa-centercode:before {
+ 	content: "\F380"
+ }
+
+ .fa-certificate:before {
+ 	content: "\F0A3"
+ }
+
+ .fa-chart-area:before {
+ 	content: "\F1FE"
+ }
+
+ .fa-chart-bar:before {
+ 	content: "\F080"
+ }
+
+ .fa-chart-line:before {
+ 	content: "\F201"
+ }
+
+ .fa-chart-pie:before {
+ 	content: "\F200"
+ }
+
+ .fa-check:before {
+ 	content: "\F00C"
+ }
+
+ .fa-check-circle:before {
+ 	content: "\F058"
+ }
+
+ .fa-check-square:before {
+ 	content: "\F14A"
+ }
+
+ .fa-chess:before {
+ 	content: "\F439"
+ }
+
+ .fa-chess-bishop:before {
+ 	content: "\F43A"
+ }
+
+ .fa-chess-board:before {
+ 	content: "\F43C"
+ }
+
+ .fa-chess-king:before {
+ 	content: "\F43F"
+ }
+
+ .fa-chess-knight:before {
+ 	content: "\F441"
+ }
+
+ .fa-chess-pawn:before {
+ 	content: "\F443"
+ }
+
+ .fa-chess-queen:before {
+ 	content: "\F445"
+ }
+
+ .fa-chess-rook:before {
+ 	content: "\F447"
+ }
+
+ .fa-chevron-circle-down:before {
+ 	content: "\F13A"
+ }
+
+ .fa-chevron-circle-left:before {
+ 	content: "\F137"
+ }
+
+ .fa-chevron-circle-right:before {
+ 	content: "\F138"
+ }
+
+ .fa-chevron-circle-up:before {
+ 	content: "\F139"
+ }
+
+ .fa-chevron-down:before {
+ 	content: "\F078"
+ }
+
+ .fa-chevron-left:before {
+ 	content: "\F053"
+ }
+
+ .fa-chevron-right:before {
+ 	content: "\F054"
+ }
+
+ .fa-chevron-up:before {
+ 	content: "\F077"
+ }
+
+ .fa-child:before {
+ 	content: "\F1AE"
+ }
+
+ .fa-chrome:before {
+ 	content: "\F268"
+ }
+
+ .fa-circle:before {
+ 	content: "\F111"
+ }
+
+ .fa-circle-notch:before {
+ 	content: "\F1CE"
+ }
+
+ .fa-clipboard:before {
+ 	content: "\F328"
+ }
+
+ .fa-clock:before {
+ 	content: "\F017"
+ }
+
+ .fa-clone:before {
+ 	content: "\F24D"
+ }
+
+ .fa-closed-captioning:before {
+ 	content: "\F20A"
+ }
+
+ .fa-cloud:before {
+ 	content: "\F0C2"
+ }
+
+ .fa-cloud-download-alt:before {
+ 	content: "\F381"
+ }
+
+ .fa-cloud-upload-alt:before {
+ 	content: "\F382"
+ }
+
+ .fa-cloudscale:before {
+ 	content: "\F383"
+ }
+
+ .fa-cloudsmith:before {
+ 	content: "\F384"
+ }
+
+ .fa-cloudversify:before {
+ 	content: "\F385"
+ }
+
+ .fa-code:before {
+ 	content: "\F121"
+ }
+
+ .fa-code-branch:before {
+ 	content: "\F126"
+ }
+
+ .fa-codepen:before {
+ 	content: "\F1CB"
+ }
+
+ .fa-codiepie:before {
+ 	content: "\F284"
+ }
+
+ .fa-coffee:before {
+ 	content: "\F0F4"
+ }
+
+ .fa-cog:before {
+ 	content: "\F013"
+ }
+
+ .fa-cogs:before {
+ 	content: "\F085"
+ }
+
+ .fa-columns:before {
+ 	content: "\F0DB"
+ }
+
+ .fa-comment:before {
+ 	content: "\F075"
+ }
+
+ .fa-comment-alt:before {
+ 	content: "\F27A"
+ }
+
+ .fa-comments:before {
+ 	content: "\F086"
+ }
+
+ .fa-compass:before {
+ 	content: "\F14E"
+ }
+
+ .fa-compress:before {
+ 	content: "\F066"
+ }
+
+ .fa-connectdevelop:before {
+ 	content: "\F20E"
+ }
+
+ .fa-contao:before {
+ 	content: "\F26D"
+ }
+
+ .fa-copy:before {
+ 	content: "\F0C5"
+ }
+
+ .fa-copyright:before {
+ 	content: "\F1F9"
+ }
+
+ .fa-cpanel:before {
+ 	content: "\F388"
+ }
+
+ .fa-creative-commons:before {
+ 	content: "\F25E"
+ }
+
+ .fa-credit-card:before {
+ 	content: "\F09D"
+ }
+
+ .fa-crop:before {
+ 	content: "\F125"
+ }
+
+ .fa-crosshairs:before {
+ 	content: "\F05B"
+ }
+
+ .fa-css3:before {
+ 	content: "\F13C"
+ }
+
+ .fa-css3-alt:before {
+ 	content: "\F38B"
+ }
+
+ .fa-cube:before {
+ 	content: "\F1B2"
+ }
+
+ .fa-cubes:before {
+ 	content: "\F1B3"
+ }
+
+ .fa-cut:before {
+ 	content: "\F0C4"
+ }
+
+ .fa-cuttlefish:before {
+ 	content: "\F38C"
+ }
+
+ .fa-d-and-d:before {
+ 	content: "\F38D"
+ }
+
+ .fa-dashcube:before {
+ 	content: "\F210"
+ }
+
+ .fa-database:before {
+ 	content: "\F1C0"
+ }
+
+ .fa-deaf:before {
+ 	content: "\F2A4"
+ }
+
+ .fa-delicious:before {
+ 	content: "\F1A5"
+ }
+
+ .fa-deploydog:before {
+ 	content: "\F38E"
+ }
+
+ .fa-deskpro:before {
+ 	content: "\F38F"
+ }
+
+ .fa-desktop:before {
+ 	content: "\F108"
+ }
+
+ .fa-deviantart:before {
+ 	content: "\F1BD"
+ }
+
+ .fa-digg:before {
+ 	content: "\F1A6"
+ }
+
+ .fa-digital-ocean:before {
+ 	content: "\F391"
+ }
+
+ .fa-discord:before {
+ 	content: "\F392"
+ }
+
+ .fa-discourse:before {
+ 	content: "\F393"
+ }
+
+ .fa-dochub:before {
+ 	content: "\F394"
+ }
+
+ .fa-docker:before {
+ 	content: "\F395"
+ }
+
+ .fa-dollar-sign:before {
+ 	content: "\F155"
+ }
+
+ .fa-dot-circle:before {
+ 	content: "\F192"
+ }
+
+ .fa-download:before {
+ 	content: "\F019"
+ }
+
+ .fa-draft2digital:before {
+ 	content: "\F396"
+ }
+
+ .fa-dribbble:before {
+ 	content: "\F17D"
+ }
+
+ .fa-dribbble-square:before {
+ 	content: "\F397"
+ }
+
+ .fa-dropbox:before {
+ 	content: "\F16B"
+ }
+
+ .fa-drupal:before {
+ 	content: "\F1A9"
+ }
+
+ .fa-dyalog:before {
+ 	content: "\F399"
+ }
+
+ .fa-earlybirds:before {
+ 	content: "\F39A"
+ }
+
+ .fa-edge:before {
+ 	content: "\F282"
+ }
+
+ .fa-edit:before {
+ 	content: "\F044"
+ }
+
+ .fa-eject:before {
+ 	content: "\F052"
+ }
+
+ .fa-elementor:before {
+ 	content: "\F430"
+ }
+
+ .fa-ellipsis-h:before {
+ 	content: "\F141"
+ }
+
+ .fa-ellipsis-v:before {
+ 	content: "\F142"
+ }
+
+ .fa-ember:before {
+ 	content: "\F423"
+ }
+
+ .fa-empire:before {
+ 	content: "\F1D1"
+ }
+
+ .fa-envelope:before {
+ 	content: "\F0E0"
+ }
+
+ .fa-envelope-open:before {
+ 	content: "\F2B6"
+ }
+
+ .fa-envelope-square:before {
+ 	content: "\F199"
+ }
+
+ .fa-envira:before {
+ 	content: "\F299"
+ }
+
+ .fa-eraser:before {
+ 	content: "\F12D"
+ }
+
+ .fa-erlang:before {
+ 	content: "\F39D"
+ }
+
+ .fa-ethereum:before {
+ 	content: "\F42E"
+ }
+
+ .fa-etsy:before {
+ 	content: "\F2D7"
+ }
+
+ .fa-euro-sign:before {
+ 	content: "\F153"
+ }
+
+ .fa-exchange-alt:before {
+ 	content: "\F362"
+ }
+
+ .fa-exclamation:before {
+ 	content: "\F12A"
+ }
+
+ .fa-exclamation-circle:before {
+ 	content: "\F06A"
+ }
+
+ .fa-exclamation-triangle:before {
+ 	content: "\F071"
+ }
+
+ .fa-expand:before {
+ 	content: "\F065"
+ }
+
+ .fa-expand-arrows-alt:before {
+ 	content: "\F31E"
+ }
+
+ .fa-expeditedssl:before {
+ 	content: "\F23E"
+ }
+
+ .fa-external-link-alt:before {
+ 	content: "\F35D"
+ }
+
+ .fa-external-link-square-alt:before {
+ 	content: "\F360"
+ }
+
+ .fa-eye:before {
+ 	content: "\F06E"
+ }
+
+ .fa-eye-dropper:before {
+ 	content: "\F1FB"
+ }
+
+ .fa-eye-slash:before {
+ 	content: "\F070"
+ }
+
+ .fa-facebook:before {
+ 	content: "\F09A"
+ }
+
+ .fa-facebook-f:before {
+ 	content: "\F39E"
+ }
+
+ .fa-facebook-messenger:before {
+ 	content: "\F39F"
+ }
+
+ .fa-facebook-square:before {
+ 	content: "\F082"
+ }
+
+ .fa-fast-backward:before {
+ 	content: "\F049"
+ }
+
+ .fa-fast-forward:before {
+ 	content: "\F050"
+ }
+
+ .fa-fax:before {
+ 	content: "\F1AC"
+ }
+
+ .fa-female:before {
+ 	content: "\F182"
+ }
+
+ .fa-fighter-jet:before {
+ 	content: "\F0FB"
+ }
+
+ .fa-file:before {
+ 	content: "\F15B"
+ }
+
+ .fa-file-alt:before {
+ 	content: "\F15C"
+ }
+
+ .fa-file-archive:before {
+ 	content: "\F1C6"
+ }
+
+ .fa-file-audio:before {
+ 	content: "\F1C7"
+ }
+
+ .fa-file-code:before {
+ 	content: "\F1C9"
+ }
+
+ .fa-file-excel:before {
+ 	content: "\F1C3"
+ }
+
+ .fa-file-image:before {
+ 	content: "\F1C5"
+ }
+
+ .fa-file-pdf:before {
+ 	content: "\F1C1"
+ }
+
+ .fa-file-powerpoint:before {
+ 	content: "\F1C4"
+ }
+
+ .fa-file-video:before {
+ 	content: "\F1C8"
+ }
+
+ .fa-file-word:before {
+ 	content: "\F1C2"
+ }
+
+ .fa-film:before {
+ 	content: "\F008"
+ }
+
+ .fa-filter:before {
+ 	content: "\F0B0"
+ }
+
+ .fa-fire:before {
+ 	content: "\F06D"
+ }
+
+ .fa-fire-extinguisher:before {
+ 	content: "\F134"
+ }
+
+ .fa-firefox:before {
+ 	content: "\F269"
+ }
+
+ .fa-first-order:before {
+ 	content: "\F2B0"
+ }
+
+ .fa-firstdraft:before {
+ 	content: "\F3A1"
+ }
+
+ .fa-flag:before {
+ 	content: "\F024"
+ }
+
+ .fa-flag-checkered:before {
+ 	content: "\F11E"
+ }
+
+ .fa-flask:before {
+ 	content: "\F0C3"
+ }
+
+ .fa-flickr:before {
+ 	content: "\F16E"
+ }
+
+ .fa-flipboard:before {
+ 	content: "\F44D"
+ }
+
+ .fa-fly:before {
+ 	content: "\F417"
+ }
+
+ .fa-folder:before {
+ 	content: "\F07B"
+ }
+
+ .fa-folder-open:before {
+ 	content: "\F07C"
+ }
+
+ .fa-font:before {
+ 	content: "\F031"
+ }
+
+ .fa-font-awesome:before {
+ 	content: "\F2B4"
+ }
+
+ .fa-font-awesome-alt:before {
+ 	content: "\F35C"
+ }
+
+ .fa-font-awesome-flag:before {
+ 	content: "\F425"
+ }
+
+ .fa-fonticons:before {
+ 	content: "\F280"
+ }
+
+ .fa-fonticons-fi:before {
+ 	content: "\F3A2"
+ }
+
+ .fa-football-ball:before {
+ 	content: "\F44E"
+ }
+
+ .fa-fort-awesome:before {
+ 	content: "\F286"
+ }
+
+ .fa-fort-awesome-alt:before {
+ 	content: "\F3A3"
+ }
+
+ .fa-forumbee:before {
+ 	content: "\F211"
+ }
+
+ .fa-forward:before {
+ 	content: "\F04E"
+ }
+
+ .fa-foursquare:before {
+ 	content: "\F180"
+ }
+
+ .fa-free-code-camp:before {
+ 	content: "\F2C5"
+ }
+
+ .fa-freebsd:before {
+ 	content: "\F3A4"
+ }
+
+ .fa-frown:before {
+ 	content: "\F119"
+ }
+
+ .fa-futbol:before {
+ 	content: "\F1E3"
+ }
+
+ .fa-gamepad:before {
+ 	content: "\F11B"
+ }
+
+ .fa-gavel:before {
+ 	content: "\F0E3"
+ }
+
+ .fa-gem:before {
+ 	content: "\F3A5"
+ }
+
+ .fa-genderless:before {
+ 	content: "\F22D"
+ }
+
+ .fa-get-pocket:before {
+ 	content: "\F265"
+ }
+
+ .fa-gg:before {
+ 	content: "\F260"
+ }
+
+ .fa-gg-circle:before {
+ 	content: "\F261"
+ }
+
+ .fa-gift:before {
+ 	content: "\F06B"
+ }
+
+ .fa-git:before {
+ 	content: "\F1D3"
+ }
+
+ .fa-git-square:before {
+ 	content: "\F1D2"
+ }
+
+ .fa-github:before {
+ 	content: "\F09B"
+ }
+
+ .fa-github-alt:before {
+ 	content: "\F113"
+ }
+
+ .fa-github-square:before {
+ 	content: "\F092"
+ }
+
+ .fa-gitkraken:before {
+ 	content: "\F3A6"
+ }
+
+ .fa-gitlab:before {
+ 	content: "\F296"
+ }
+
+ .fa-gitter:before {
+ 	content: "\F426"
+ }
+
+ .fa-glass-martini:before {
+ 	content: "\F000"
+ }
+
+ .fa-glide:before {
+ 	content: "\F2A5"
+ }
+
+ .fa-glide-g:before {
+ 	content: "\F2A6"
+ }
+
+ .fa-globe:before {
+ 	content: "\F0AC"
+ }
+
+ .fa-gofore:before {
+ 	content: "\F3A7"
+ }
+
+ .fa-golf-ball:before {
+ 	content: "\F450"
+ }
+
+ .fa-goodreads:before {
+ 	content: "\F3A8"
+ }
+
+ .fa-goodreads-g:before {
+ 	content: "\F3A9"
+ }
+
+ .fa-google:before {
+ 	content: "\F1A0"
+ }
+
+ .fa-google-drive:before {
+ 	content: "\F3AA"
+ }
+
+ .fa-google-play:before {
+ 	content: "\F3AB"
+ }
+
+ .fa-google-plus:before {
+ 	content: "\F2B3"
+ }
+
+ .fa-google-plus-g:before {
+ 	content: "\F0D5"
+ }
+
+ .fa-google-plus-square:before {
+ 	content: "\F0D4"
+ }
+
+ .fa-google-wallet:before {
+ 	content: "\F1EE"
+ }
+
+ .fa-graduation-cap:before {
+ 	content: "\F19D"
+ }
+
+ .fa-gratipay:before {
+ 	content: "\F184"
+ }
+
+ .fa-grav:before {
+ 	content: "\F2D6"
+ }
+
+ .fa-gripfire:before {
+ 	content: "\F3AC"
+ }
+
+ .fa-grunt:before {
+ 	content: "\F3AD"
+ }
+
+ .fa-gulp:before {
+ 	content: "\F3AE"
+ }
+
+ .fa-h-square:before {
+ 	content: "\F0FD"
+ }
+
+ .fa-hacker-news:before {
+ 	content: "\F1D4"
+ }
+
+ .fa-hacker-news-square:before {
+ 	content: "\F3AF"
+ }
+
+ .fa-hand-lizard:before {
+ 	content: "\F258"
+ }
+
+ .fa-hand-paper:before {
+ 	content: "\F256"
+ }
+
+ .fa-hand-peace:before {
+ 	content: "\F25B"
+ }
+
+ .fa-hand-point-down:before {
+ 	content: "\F0A7"
+ }
+
+ .fa-hand-point-left:before {
+ 	content: "\F0A5"
+ }
+
+ .fa-hand-point-right:before {
+ 	content: "\F0A4"
+ }
+
+ .fa-hand-point-up:before {
+ 	content: "\F0A6"
+ }
+
+ .fa-hand-pointer:before {
+ 	content: "\F25A"
+ }
+
+ .fa-hand-rock:before {
+ 	content: "\F255"
+ }
+
+ .fa-hand-scissors:before {
+ 	content: "\F257"
+ }
+
+ .fa-hand-spock:before {
+ 	content: "\F259"
+ }
+
+ .fa-handshake:before {
+ 	content: "\F2B5"
+ }
+
+ .fa-hashtag:before {
+ 	content: "\F292"
+ }
+
+ .fa-hdd:before {
+ 	content: "\F0A0"
+ }
+
+ .fa-heading:before {
+ 	content: "\F1DC"
+ }
+
+ .fa-headphones:before {
+ 	content: "\F025"
+ }
+
+ .fa-heart:before {
+ 	content: "\F004"
+ }
+
+ .fa-heartbeat:before {
+ 	content: "\F21E"
+ }
+
+ .fa-hips:before {
+ 	content: "\F452"
+ }
+
+ .fa-hire-a-helper:before {
+ 	content: "\F3B0"
+ }
+
+ .fa-history:before {
+ 	content: "\F1DA"
+ }
+
+ .fa-hockey-puck:before {
+ 	content: "\F453"
+ }
+
+ .fa-home:before {
+ 	content: "\F015"
+ }
+
+ .fa-hooli:before {
+ 	content: "\F427"
+ }
+
+ .fa-hospital:before {
+ 	content: "\F0F8"
+ }
+
+ .fa-hotjar:before {
+ 	content: "\F3B1"
+ }
+
+ .fa-hourglass:before {
+ 	content: "\F254"
+ }
+
+ .fa-hourglass-end:before {
+ 	content: "\F253"
+ }
+
+ .fa-hourglass-half:before {
+ 	content: "\F252"
+ }
+
+ .fa-hourglass-start:before {
+ 	content: "\F251"
+ }
+
+ .fa-houzz:before {
+ 	content: "\F27C"
+ }
+
+ .fa-html5:before {
+ 	content: "\F13B"
+ }
+
+ .fa-hubspot:before {
+ 	content: "\F3B2"
+ }
+
+ .fa-i-cursor:before {
+ 	content: "\F246"
+ }
+
+ .fa-id-badge:before {
+ 	content: "\F2C1"
+ }
+
+ .fa-id-card:before {
+ 	content: "\F2C2"
+ }
+
+ .fa-image:before {
+ 	content: "\F03E"
+ }
+
+ .fa-images:before {
+ 	content: "\F302"
+ }
+
+ .fa-imdb:before {
+ 	content: "\F2D8"
+ }
+
+ .fa-inbox:before {
+ 	content: "\F01C"
+ }
+
+ .fa-indent:before {
+ 	content: "\F03C"
+ }
+
+ .fa-industry:before {
+ 	content: "\F275"
+ }
+
+ .fa-info:before {
+ 	content: "\F129"
+ }
+
+ .fa-info-circle:before {
+ 	content: "\F05A"
+ }
+
+ .fa-instagram:before {
+ 	content: "\F16D"
+ }
+
+ .fa-internet-explorer:before {
+ 	content: "\F26B"
+ }
+
+ .fa-ioxhost:before {
+ 	content: "\F208"
+ }
+
+ .fa-italic:before {
+ 	content: "\F033"
+ }
+
+ .fa-itunes:before {
+ 	content: "\F3B4"
+ }
+
+ .fa-itunes-note:before {
+ 	content: "\F3B5"
+ }
+
+ .fa-jenkins:before {
+ 	content: "\F3B6"
+ }
+
+ .fa-joget:before {
+ 	content: "\F3B7"
+ }
+
+ .fa-joomla:before {
+ 	content: "\F1AA"
+ }
+
+ .fa-js:before {
+ 	content: "\F3B8"
+ }
+
+ .fa-js-square:before {
+ 	content: "\F3B9"
+ }
+
+ .fa-jsfiddle:before {
+ 	content: "\F1CC"
+ }
+
+ .fa-key:before {
+ 	content: "\F084"
+ }
+
+ .fa-keyboard:before {
+ 	content: "\F11C"
+ }
+
+ .fa-keycdn:before {
+ 	content: "\F3BA"
+ }
+
+ .fa-kickstarter:before {
+ 	content: "\F3BB"
+ }
+
+ .fa-kickstarter-k:before {
+ 	content: "\F3BC"
+ }
+
+ .fa-korvue:before {
+ 	content: "\F42F"
+ }
+
+ .fa-language:before {
+ 	content: "\F1AB"
+ }
+
+ .fa-laptop:before {
+ 	content: "\F109"
+ }
+
+ .fa-laravel:before {
+ 	content: "\F3BD"
+ }
+
+ .fa-lastfm:before {
+ 	content: "\F202"
+ }
+
+ .fa-lastfm-square:before {
+ 	content: "\F203"
+ }
+
+ .fa-leaf:before {
+ 	content: "\F06C"
+ }
+
+ .fa-leanpub:before {
+ 	content: "\F212"
+ }
+
+ .fa-lemon:before {
+ 	content: "\F094"
+ }
+
+ .fa-less:before {
+ 	content: "\F41D"
+ }
+
+ .fa-level-down-alt:before {
+ 	content: "\F3BE"
+ }
+
+ .fa-level-up-alt:before {
+ 	content: "\F3BF"
+ }
+
+ .fa-life-ring:before {
+ 	content: "\F1CD"
+ }
+
+ .fa-lightbulb:before {
+ 	content: "\F0EB"
+ }
+
+ .fa-line:before {
+ 	content: "\F3C0"
+ }
+
+ .fa-link:before {
+ 	content: "\F0C1"
+ }
+
+ .fa-linkedin:before {
+ 	content: "\F08C"
+ }
+
+ .fa-linkedin-in:before {
+ 	content: "\F0E1"
+ }
+
+ .fa-linode:before {
+ 	content: "\F2B8"
+ }
+
+ .fa-linux:before {
+ 	content: "\F17C"
+ }
+
+ .fa-lira-sign:before {
+ 	content: "\F195"
+ }
+
+ .fa-list:before {
+ 	content: "\F03A"
+ }
+
+ .fa-list-alt:before {
+ 	content: "\F022"
+ }
+
+ .fa-list-ol:before {
+ 	content: "\F0CB"
+ }
+
+ .fa-list-ul:before {
+ 	content: "\F0CA"
+ }
+
+ .fa-location-arrow:before {
+ 	content: "\F124"
+ }
+
+ .fa-lock:before {
+ 	content: "\F023"
+ }
+
+ .fa-lock-open:before {
+ 	content: "\F3C1"
+ }
+
+ .fa-long-arrow-alt-down:before {
+ 	content: "\F309"
+ }
+
+ .fa-long-arrow-alt-left:before {
+ 	content: "\F30A"
+ }
+
+ .fa-long-arrow-alt-right:before {
+ 	content: "\F30B"
+ }
+
+ .fa-long-arrow-alt-up:before {
+ 	content: "\F30C"
+ }
+
+ .fa-low-vision:before {
+ 	content: "\F2A8"
+ }
+
+ .fa-lyft:before {
+ 	content: "\F3C3"
+ }
+
+ .fa-magento:before {
+ 	content: "\F3C4"
+ }
+
+ .fa-magic:before {
+ 	content: "\F0D0"
+ }
+
+ .fa-magnet:before {
+ 	content: "\F076"
+ }
+
+ .fa-male:before {
+ 	content: "\F183"
+ }
+
+ .fa-map:before {
+ 	content: "\F279"
+ }
+
+ .fa-map-marker:before {
+ 	content: "\F041"
+ }
+
+ .fa-map-marker-alt:before {
+ 	content: "\F3C5"
+ }
+
+ .fa-map-pin:before {
+ 	content: "\F276"
+ }
+
+ .fa-map-signs:before {
+ 	content: "\F277"
+ }
+
+ .fa-mars:before {
+ 	content: "\F222"
+ }
+
+ .fa-mars-double:before {
+ 	content: "\F227"
+ }
+
+ .fa-mars-stroke:before {
+ 	content: "\F229"
+ }
+
+ .fa-mars-stroke-h:before {
+ 	content: "\F22B"
+ }
+
+ .fa-mars-stroke-v:before {
+ 	content: "\F22A"
+ }
+
+ .fa-maxcdn:before {
+ 	content: "\F136"
+ }
+
+ .fa-medapps:before {
+ 	content: "\F3C6"
+ }
+
+ .fa-medium:before {
+ 	content: "\F23A"
+ }
+
+ .fa-medium-m:before {
+ 	content: "\F3C7"
+ }
+
+ .fa-medkit:before {
+ 	content: "\F0FA"
+ }
+
+ .fa-medrt:before {
+ 	content: "\F3C8"
+ }
+
+ .fa-meetup:before {
+ 	content: "\F2E0"
+ }
+
+ .fa-meh:before {
+ 	content: "\F11A"
+ }
+
+ .fa-mercury:before {
+ 	content: "\F223"
+ }
+
+ .fa-microchip:before {
+ 	content: "\F2DB"
+ }
+
+ .fa-microphone:before {
+ 	content: "\F130"
+ }
+
+ .fa-microphone-slash:before {
+ 	content: "\F131"
+ }
+
+ .fa-microsoft:before {
+ 	content: "\F3CA"
+ }
+
+ .fa-minus:before {
+ 	content: "\F068"
+ }
+
+ .fa-minus-circle:before {
+ 	content: "\F056"
+ }
+
+ .fa-minus-square:before {
+ 	content: "\F146"
+ }
+
+ .fa-mix:before {
+ 	content: "\F3CB"
+ }
+
+ .fa-mixcloud:before {
+ 	content: "\F289"
+ }
+
+ .fa-mizuni:before {
+ 	content: "\F3CC"
+ }
+
+ .fa-mobile:before {
+ 	content: "\F10B"
+ }
+
+ .fa-mobile-alt:before {
+ 	content: "\F3CD"
+ }
+
+ .fa-modx:before {
+ 	content: "\F285"
+ }
+
+ .fa-monero:before {
+ 	content: "\F3D0"
+ }
+
+ .fa-money-bill-alt:before {
+ 	content: "\F3D1"
+ }
+
+ .fa-moon:before {
+ 	content: "\F186"
+ }
+
+ .fa-motorcycle:before {
+ 	content: "\F21C"
+ }
+
+ .fa-mouse-pointer:before {
+ 	content: "\F245"
+ }
+
+ .fa-music:before {
+ 	content: "\F001"
+ }
+
+ .fa-napster:before {
+ 	content: "\F3D2"
+ }
+
+ .fa-neuter:before {
+ 	content: "\F22C"
+ }
+
+ .fa-newspaper:before {
+ 	content: "\F1EA"
+ }
+
+ .fa-nintendo-switch:before {
+ 	content: "\F418"
+ }
+
+ .fa-node:before {
+ 	content: "\F419"
+ }
+
+ .fa-node-js:before {
+ 	content: "\F3D3"
+ }
+
+ .fa-npm:before {
+ 	content: "\F3D4"
+ }
+
+ .fa-ns8:before {
+ 	content: "\F3D5"
+ }
+
+ .fa-nutritionix:before {
+ 	content: "\F3D6"
+ }
+
+ .fa-object-group:before {
+ 	content: "\F247"
+ }
+
+ .fa-object-ungroup:before {
+ 	content: "\F248"
+ }
+
+ .fa-odnoklassniki:before {
+ 	content: "\F263"
+ }
+
+ .fa-odnoklassniki-square:before {
+ 	content: "\F264"
+ }
+
+ .fa-opencart:before {
+ 	content: "\F23D"
+ }
+
+ .fa-openid:before {
+ 	content: "\F19B"
+ }
+
+ .fa-opera:before {
+ 	content: "\F26A"
+ }
+
+ .fa-optin-monster:before {
+ 	content: "\F23C"
+ }
+
+ .fa-osi:before {
+ 	content: "\F41A"
+ }
+
+ .fa-outdent:before {
+ 	content: "\F03B"
+ }
+
+ .fa-page4:before {
+ 	content: "\F3D7"
+ }
+
+ .fa-pagelines:before {
+ 	content: "\F18C"
+ }
+
+ .fa-paint-brush:before {
+ 	content: "\F1FC"
+ }
+
+ .fa-palfed:before {
+ 	content: "\F3D8"
+ }
+
+ .fa-paper-plane:before {
+ 	content: "\F1D8"
+ }
+
+ .fa-paperclip:before {
+ 	content: "\F0C6"
+ }
+
+ .fa-paragraph:before {
+ 	content: "\F1DD"
+ }
+
+ .fa-paste:before {
+ 	content: "\F0EA"
+ }
+
+ .fa-patreon:before {
+ 	content: "\F3D9"
+ }
+
+ .fa-pause:before {
+ 	content: "\F04C"
+ }
+
+ .fa-pause-circle:before {
+ 	content: "\F28B"
+ }
+
+ .fa-paw:before {
+ 	content: "\F1B0"
+ }
+
+ .fa-paypal:before {
+ 	content: "\F1ED"
+ }
+
+ .fa-pen-square:before {
+ 	content: "\F14B"
+ }
+
+ .fa-pencil-alt:before {
+ 	content: "\F303"
+ }
+
+ .fa-percent:before {
+ 	content: "\F295"
+ }
+
+ .fa-periscope:before {
+ 	content: "\F3DA"
+ }
+
+ .fa-phabricator:before {
+ 	content: "\F3DB"
+ }
+
+ .fa-phoenix-framework:before {
+ 	content: "\F3DC"
+ }
+
+ .fa-phone:before {
+ 	content: "\F095"
+ }
+
+ .fa-phone-square:before {
+ 	content: "\F098"
+ }
+
+ .fa-phone-volume:before {
+ 	content: "\F2A0"
+ }
+
+ .fa-php:before {
+ 	content: "\F457"
+ }
+
+ .fa-pied-piper:before {
+ 	content: "\F2AE"
+ }
+
+ .fa-pied-piper-alt:before {
+ 	content: "\F1A8"
+ }
+
+ .fa-pied-piper-pp:before {
+ 	content: "\F1A7"
+ }
+
+ .fa-pinterest:before {
+ 	content: "\F0D2"
+ }
+
+ .fa-pinterest-p:before {
+ 	content: "\F231"
+ }
+
+ .fa-pinterest-square:before {
+ 	content: "\F0D3"
+ }
+
+ .fa-plane:before {
+ 	content: "\F072"
+ }
+
+ .fa-play:before {
+ 	content: "\F04B"
+ }
+
+ .fa-play-circle:before {
+ 	content: "\F144"
+ }
+
+ .fa-playstation:before {
+ 	content: "\F3DF"
+ }
+
+ .fa-plug:before {
+ 	content: "\F1E6"
+ }
+
+ .fa-plus:before {
+ 	content: "\F067"
+ }
+
+ .fa-plus-circle:before {
+ 	content: "\F055"
+ }
+
+ .fa-plus-square:before {
+ 	content: "\F0FE"
+ }
+
+ .fa-podcast:before {
+ 	content: "\F2CE"
+ }
+
+ .fa-pound-sign:before {
+ 	content: "\F154"
+ }
+
+ .fa-power-off:before {
+ 	content: "\F011"
+ }
+
+ .fa-print:before {
+ 	content: "\F02F"
+ }
+
+ .fa-product-hunt:before {
+ 	content: "\F288"
+ }
+
+ .fa-pushed:before {
+ 	content: "\F3E1"
+ }
+
+ .fa-puzzle-piece:before {
+ 	content: "\F12E"
+ }
+
+ .fa-python:before {
+ 	content: "\F3E2"
+ }
+
+ .fa-qq:before {
+ 	content: "\F1D6"
+ }
+
+ .fa-qrcode:before {
+ 	content: "\F029"
+ }
+
+ .fa-question:before {
+ 	content: "\F128"
+ }
+
+ .fa-question-circle:before {
+ 	content: "\F059"
+ }
+
+ .fa-quidditch:before {
+ 	content: "\F458"
+ }
+
+ .fa-quinscape:before {
+ 	content: "\F459"
+ }
+
+ .fa-quora:before {
+ 	content: "\F2C4"
+ }
+
+ .fa-quote-left:before {
+ 	content: "\F10D"
+ }
+
+ .fa-quote-right:before {
+ 	content: "\F10E"
+ }
+
+ .fa-random:before {
+ 	content: "\F074"
+ }
+
+ .fa-ravelry:before {
+ 	content: "\F2D9"
+ }
+
+ .fa-react:before {
+ 	content: "\F41B"
+ }
+
+ .fa-rebel:before {
+ 	content: "\F1D0"
+ }
+
+ .fa-recycle:before {
+ 	content: "\F1B8"
+ }
+
+ .fa-red-river:before {
+ 	content: "\F3E3"
+ }
+
+ .fa-reddit:before {
+ 	content: "\F1A1"
+ }
+
+ .fa-reddit-alien:before {
+ 	content: "\F281"
+ }
+
+ .fa-reddit-square:before {
+ 	content: "\F1A2"
+ }
+
+ .fa-redo:before {
+ 	content: "\F01E"
+ }
+
+ .fa-redo-alt:before {
+ 	content: "\F2F9"
+ }
+
+ .fa-registered:before {
+ 	content: "\F25D"
+ }
+
+ .fa-rendact:before {
+ 	content: "\F3E4"
+ }
+
+ .fa-renren:before {
+ 	content: "\F18B"
+ }
+
+ .fa-reply:before {
+ 	content: "\F3E5"
+ }
+
+ .fa-reply-all:before {
+ 	content: "\F122"
+ }
+
+ .fa-replyd:before {
+ 	content: "\F3E6"
+ }
+
+ .fa-resolving:before {
+ 	content: "\F3E7"
+ }
+
+ .fa-retweet:before {
+ 	content: "\F079"
+ }
+
+ .fa-road:before {
+ 	content: "\F018"
+ }
+
+ .fa-rocket:before {
+ 	content: "\F135"
+ }
+
+ .fa-rocketchat:before {
+ 	content: "\F3E8"
+ }
+
+ .fa-rockrms:before {
+ 	content: "\F3E9"
+ }
+
+ .fa-rss:before {
+ 	content: "\F09E"
+ }
+
+ .fa-rss-square:before {
+ 	content: "\F143"
+ }
+
+ .fa-ruble-sign:before {
+ 	content: "\F158"
+ }
+
+ .fa-rupee-sign:before {
+ 	content: "\F156"
+ }
+
+ .fa-safari:before {
+ 	content: "\F267"
+ }
+
+ .fa-sass:before {
+ 	content: "\F41E"
+ }
+
+ .fa-save:before {
+ 	content: "\F0C7"
+ }
+
+ .fa-schlix:before {
+ 	content: "\F3EA"
+ }
+
+ .fa-scribd:before {
+ 	content: "\F28A"
+ }
+
+ .fa-search:before {
+ 	content: "\F002"
+ }
+
+ .fa-search-minus:before {
+ 	content: "\F010"
+ }
+
+ .fa-search-plus:before {
+ 	content: "\F00E"
+ }
+
+ .fa-searchengin:before {
+ 	content: "\F3EB"
+ }
+
+ .fa-sellcast:before {
+ 	content: "\F2DA"
+ }
+
+ .fa-sellsy:before {
+ 	content: "\F213"
+ }
+
+ .fa-server:before {
+ 	content: "\F233"
+ }
+
+ .fa-servicestack:before {
+ 	content: "\F3EC"
+ }
+
+ .fa-share:before {
+ 	content: "\F064"
+ }
+
+ .fa-share-alt:before {
+ 	content: "\F1E0"
+ }
+
+ .fa-share-alt-square:before {
+ 	content: "\F1E1"
+ }
+
+ .fa-share-square:before {
+ 	content: "\F14D"
+ }
+
+ .fa-shekel-sign:before {
+ 	content: "\F20B"
+ }
+
+ .fa-shield-alt:before {
+ 	content: "\F3ED"
+ }
+
+ .fa-ship:before {
+ 	content: "\F21A"
+ }
+
+ .fa-shirtsinbulk:before {
+ 	content: "\F214"
+ }
+
+ .fa-shopping-bag:before {
+ 	content: "\F290"
+ }
+
+ .fa-shopping-basket:before {
+ 	content: "\F291"
+ }
+
+ .fa-shopping-cart:before {
+ 	content: "\F07A"
+ }
+
+ .fa-shower:before {
+ 	content: "\F2CC"
+ }
+
+ .fa-sign-in-alt:before {
+ 	content: "\F2F6"
+ }
+
+ .fa-sign-language:before {
+ 	content: "\F2A7"
+ }
+
+ .fa-sign-out-alt:before {
+ 	content: "\F2F5"
+ }
+
+ .fa-signal:before {
+ 	content: "\F012"
+ }
+
+ .fa-simplybuilt:before {
+ 	content: "\F215"
+ }
+
+ .fa-sistrix:before {
+ 	content: "\F3EE"
+ }
+
+ .fa-sitemap:before {
+ 	content: "\F0E8"
+ }
+
+ .fa-skyatlas:before {
+ 	content: "\F216"
+ }
+
+ .fa-skype:before {
+ 	content: "\F17E"
+ }
+
+ .fa-slack:before {
+ 	content: "\F198"
+ }
+
+ .fa-slack-hash:before {
+ 	content: "\F3EF"
+ }
+
+ .fa-sliders-h:before {
+ 	content: "\F1DE"
+ }
+
+ .fa-slideshare:before {
+ 	content: "\F1E7"
+ }
+
+ .fa-smile:before {
+ 	content: "\F118"
+ }
+
+ .fa-snapchat:before {
+ 	content: "\F2AB"
+ }
+
+ .fa-snapchat-ghost:before {
+ 	content: "\F2AC"
+ }
+
+ .fa-snapchat-square:before {
+ 	content: "\F2AD"
+ }
+
+ .fa-snowflake:before {
+ 	content: "\F2DC"
+ }
+
+ .fa-sort:before {
+ 	content: "\F0DC"
+ }
+
+ .fa-sort-alpha-down:before {
+ 	content: "\F15D"
+ }
+
+ .fa-sort-alpha-up:before {
+ 	content: "\F15E"
+ }
+
+ .fa-sort-amount-down:before {
+ 	content: "\F160"
+ }
+
+ .fa-sort-amount-up:before {
+ 	content: "\F161"
+ }
+
+ .fa-sort-down:before {
+ 	content: "\F0DD"
+ }
+
+ .fa-sort-numeric-down:before {
+ 	content: "\F162"
+ }
+
+ .fa-sort-numeric-up:before {
+ 	content: "\F163"
+ }
+
+ .fa-sort-up:before {
+ 	content: "\F0DE"
+ }
+
+ .fa-soundcloud:before {
+ 	content: "\F1BE"
+ }
+
+ .fa-space-shuttle:before {
+ 	content: "\F197"
+ }
+
+ .fa-speakap:before {
+ 	content: "\F3F3"
+ }
+
+ .fa-spinner:before {
+ 	content: "\F110"
+ }
+
+ .fa-spotify:before {
+ 	content: "\F1BC"
+ }
+
+ .fa-square:before {
+ 	content: "\F0C8"
+ }
+
+ .fa-square-full:before {
+ 	content: "\F45C"
+ }
+
+ .fa-stack-exchange:before {
+ 	content: "\F18D"
+ }
+
+ .fa-stack-overflow:before {
+ 	content: "\F16C"
+ }
+
+ .fa-star:before {
+ 	content: "\F005"
+ }
+
+ .fa-star-half:before {
+ 	content: "\F089"
+ }
+
+ .fa-staylinked:before {
+ 	content: "\F3F5"
+ }
+
+ .fa-steam:before {
+ 	content: "\F1B6"
+ }
+
+ .fa-steam-square:before {
+ 	content: "\F1B7"
+ }
+
+ .fa-steam-symbol:before {
+ 	content: "\F3F6"
+ }
+
+ .fa-step-backward:before {
+ 	content: "\F048"
+ }
+
+ .fa-step-forward:before {
+ 	content: "\F051"
+ }
+
+ .fa-stethoscope:before {
+ 	content: "\F0F1"
+ }
+
+ .fa-sticker-mule:before {
+ 	content: "\F3F7"
+ }
+
+ .fa-sticky-note:before {
+ 	content: "\F249"
+ }
+
+ .fa-stop:before {
+ 	content: "\F04D"
+ }
+
+ .fa-stop-circle:before {
+ 	content: "\F28D"
+ }
+
+ .fa-stopwatch:before {
+ 	content: "\F2F2"
+ }
+
+ .fa-strava:before {
+ 	content: "\F428"
+ }
+
+ .fa-street-view:before {
+ 	content: "\F21D"
+ }
+
+ .fa-strikethrough:before {
+ 	content: "\F0CC"
+ }
+
+ .fa-stripe:before {
+ 	content: "\F429"
+ }
+
+ .fa-stripe-s:before {
+ 	content: "\F42A"
+ }
+
+ .fa-studiovinari:before {
+ 	content: "\F3F8"
+ }
+
+ .fa-stumbleupon:before {
+ 	content: "\F1A4"
+ }
+
+ .fa-stumbleupon-circle:before {
+ 	content: "\F1A3"
+ }
+
+ .fa-subscript:before {
+ 	content: "\F12C"
+ }
+
+ .fa-subway:before {
+ 	content: "\F239"
+ }
+
+ .fa-suitcase:before {
+ 	content: "\F0F2"
+ }
+
+ .fa-sun:before {
+ 	content: "\F185"
+ }
+
+ .fa-superpowers:before {
+ 	content: "\F2DD"
+ }
+
+ .fa-superscript:before {
+ 	content: "\F12B"
+ }
+
+ .fa-supple:before {
+ 	content: "\F3F9"
+ }
+
+ .fa-sync:before {
+ 	content: "\F021"
+ }
+
+ .fa-sync-alt:before {
+ 	content: "\F2F1"
+ }
+
+ .fa-table:before {
+ 	content: "\F0CE"
+ }
+
+ .fa-table-tennis:before {
+ 	content: "\F45D"
+ }
+
+ .fa-tablet:before {
+ 	content: "\F10A"
+ }
+
+ .fa-tablet-alt:before {
+ 	content: "\F3FA"
+ }
+
+ .fa-tachometer-alt:before {
+ 	content: "\F3FD"
+ }
+
+ .fa-tag:before {
+ 	content: "\F02B"
+ }
+
+ .fa-tags:before {
+ 	content: "\F02C"
+ }
+
+ .fa-tasks:before {
+ 	content: "\F0AE"
+ }
+
+ .fa-taxi:before {
+ 	content: "\F1BA"
+ }
+
+ .fa-telegram:before {
+ 	content: "\F2C6"
+ }
+
+ .fa-telegram-plane:before {
+ 	content: "\F3FE"
+ }
+
+ .fa-tencent-weibo:before {
+ 	content: "\F1D5"
+ }
+
+ .fa-terminal:before {
+ 	content: "\F120"
+ }
+
+ .fa-text-height:before {
+ 	content: "\F034"
+ }
+
+ .fa-text-width:before {
+ 	content: "\F035"
+ }
+
+ .fa-th:before {
+ 	content: "\F00A"
+ }
+
+ .fa-th-large:before {
+ 	content: "\F009"
+ }
+
+ .fa-th-list:before {
+ 	content: "\F00B"
+ }
+
+ .fa-themeisle:before {
+ 	content: "\F2B2"
+ }
+
+ .fa-thermometer-empty:before {
+ 	content: "\F2CB"
+ }
+
+ .fa-thermometer-full:before {
+ 	content: "\F2C7"
+ }
+
+ .fa-thermometer-half:before {
+ 	content: "\F2C9"
+ }
+
+ .fa-thermometer-quarter:before {
+ 	content: "\F2CA"
+ }
+
+ .fa-thermometer-three-quarters:before {
+ 	content: "\F2C8"
+ }
+
+ .fa-thumbs-down:before {
+ 	content: "\F165"
+ }
+
+ .fa-thumbs-up:before {
+ 	content: "\F164"
+ }
+
+ .fa-thumbtack:before {
+ 	content: "\F08D"
+ }
+
+ .fa-ticket-alt:before {
+ 	content: "\F3FF"
+ }
+
+ .fa-times:before {
+ 	content: "\F00D"
+ }
+
+ .fa-times-circle:before {
+ 	content: "\F057"
+ }
+
+ .fa-tint:before {
+ 	content: "\F043"
+ }
+
+ .fa-toggle-off:before {
+ 	content: "\F204"
+ }
+
+ .fa-toggle-on:before {
+ 	content: "\F205"
+ }
+
+ .fa-trademark:before {
+ 	content: "\F25C"
+ }
+
+ .fa-train:before {
+ 	content: "\F238"
+ }
+
+ .fa-transgender:before {
+ 	content: "\F224"
+ }
+
+ .fa-transgender-alt:before {
+ 	content: "\F225"
+ }
+
+ .fa-trash:before {
+ 	content: "\F1F8"
+ }
+
+ .fa-trash-alt:before {
+ 	content: "\F2ED"
+ }
+
+ .fa-tree:before {
+ 	content: "\F1BB"
+ }
+
+ .fa-trello:before {
+ 	content: "\F181"
+ }
+
+ .fa-tripadvisor:before {
+ 	content: "\F262"
+ }
+
+ .fa-trophy:before {
+ 	content: "\F091"
+ }
+
+ .fa-truck:before {
+ 	content: "\F0D1"
+ }
+
+ .fa-tty:before {
+ 	content: "\F1E4"
+ }
+
+ .fa-tumblr:before {
+ 	content: "\F173"
+ }
+
+ .fa-tumblr-square:before {
+ 	content: "\F174"
+ }
+
+ .fa-tv:before {
+ 	content: "\F26C"
+ }
+
+ .fa-twitch:before {
+ 	content: "\F1E8"
+ }
+
+ .fa-twitter:before {
+ 	content: "\F099"
+ }
+
+ .fa-twitter-square:before {
+ 	content: "\F081"
+ }
+
+ .fa-typo3:before {
+ 	content: "\F42B"
+ }
+
+ .fa-uber:before {
+ 	content: "\F402"
+ }
+
+ .fa-uikit:before {
+ 	content: "\F403"
+ }
+
+ .fa-umbrella:before {
+ 	content: "\F0E9"
+ }
+
+ .fa-underline:before {
+ 	content: "\F0CD"
+ }
+
+ .fa-undo:before {
+ 	content: "\F0E2"
+ }
+
+ .fa-undo-alt:before {
+ 	content: "\F2EA"
+ }
+
+ .fa-uniregistry:before {
+ 	content: "\F404"
+ }
+
+ .fa-universal-access:before {
+ 	content: "\F29A"
+ }
+
+ .fa-university:before {
+ 	content: "\F19C"
+ }
+
+ .fa-unlink:before {
+ 	content: "\F127"
+ }
+
+ .fa-unlock:before {
+ 	content: "\F09C"
+ }
+
+ .fa-unlock-alt:before {
+ 	content: "\F13E"
+ }
+
+ .fa-untappd:before {
+ 	content: "\F405"
+ }
+
+ .fa-upload:before {
+ 	content: "\F093"
+ }
+
+ .fa-usb:before {
+ 	content: "\F287"
+ }
+
+ .fa-user:before {
+ 	content: "\F007"
+ }
+
+ .fa-user-circle:before {
+ 	content: "\F2BD"
+ }
+
+ .fa-user-md:before {
+ 	content: "\F0F0"
+ }
+
+ .fa-user-plus:before {
+ 	content: "\F234"
+ }
+
+ .fa-user-secret:before {
+ 	content: "\F21B"
+ }
+
+ .fa-user-times:before {
+ 	content: "\F235"
+ }
+
+ .fa-users:before {
+ 	content: "\F0C0"
+ }
+
+ .fa-ussunnah:before {
+ 	content: "\F407"
+ }
+
+ .fa-utensil-spoon:before {
+ 	content: "\F2E5"
+ }
+
+ .fa-utensils:before {
+ 	content: "\F2E7"
+ }
+
+ .fa-vaadin:before {
+ 	content: "\F408"
+ }
+
+ .fa-venus:before {
+ 	content: "\F221"
+ }
+
+ .fa-venus-double:before {
+ 	content: "\F226"
+ }
+
+ .fa-venus-mars:before {
+ 	content: "\F228"
+ }
+
+ .fa-viacoin:before {
+ 	content: "\F237"
+ }
+
+ .fa-viadeo:before {
+ 	content: "\F2A9"
+ }
+
+ .fa-viadeo-square:before {
+ 	content: "\F2AA"
+ }
+
+ .fa-viber:before {
+ 	content: "\F409"
+ }
+
+ .fa-video:before {
+ 	content: "\F03D"
+ }
+
+ .fa-vimeo:before {
+ 	content: "\F40A"
+ }
+
+ .fa-vimeo-square:before {
+ 	content: "\F194"
+ }
+
+ .fa-vimeo-v:before {
+ 	content: "\F27D"
+ }
+
+ .fa-vine:before {
+ 	content: "\F1CA"
+ }
+
+ .fa-vk:before {
+ 	content: "\F189"
+ }
+
+ .fa-vnv:before {
+ 	content: "\F40B"
+ }
+
+ .fa-volleyball-ball:before {
+ 	content: "\F45F"
+ }
+
+ .fa-volume-down:before {
+ 	content: "\F027"
+ }
+
+ .fa-volume-off:before {
+ 	content: "\F026"
+ }
+
+ .fa-volume-up:before {
+ 	content: "\F028"
+ }
+
+ .fa-vuejs:before {
+ 	content: "\F41F"
+ }
+
+ .fa-weibo:before {
+ 	content: "\F18A"
+ }
+
+ .fa-weixin:before {
+ 	content: "\F1D7"
+ }
+
+ .fa-whatsapp:before {
+ 	content: "\F232"
+ }
+
+ .fa-whatsapp-square:before {
+ 	content: "\F40C"
+ }
+
+ .fa-wheelchair:before {
+ 	content: "\F193"
+ }
+
+ .fa-whmcs:before {
+ 	content: "\F40D"
+ }
+
+ .fa-wifi:before {
+ 	content: "\F1EB"
+ }
+
+ .fa-wikipedia-w:before {
+ 	content: "\F266"
+ }
+
+ .fa-window-close:before {
+ 	content: "\F410"
+ }
+
+ .fa-window-maximize:before {
+ 	content: "\F2D0"
+ }
+
+ .fa-window-minimize:before {
+ 	content: "\F2D1"
+ }
+
+ .fa-window-restore:before {
+ 	content: "\F2D2"
+ }
+
+ .fa-windows:before {
+ 	content: "\F17A"
+ }
+
+ .fa-won-sign:before {
+ 	content: "\F159"
+ }
+
+ .fa-wordpress:before {
+ 	content: "\F19A"
+ }
+
+ .fa-wordpress-simple:before {
+ 	content: "\F411"
+ }
+
+ .fa-wpbeginner:before {
+ 	content: "\F297"
+ }
+
+ .fa-wpexplorer:before {
+ 	content: "\F2DE"
+ }
+
+ .fa-wpforms:before {
+ 	content: "\F298"
+ }
+
+ .fa-wrench:before {
+ 	content: "\F0AD"
+ }
+
+ .fa-xbox:before {
+ 	content: "\F412"
+ }
+
+ .fa-xing:before {
+ 	content: "\F168"
+ }
+
+ .fa-xing-square:before {
+ 	content: "\F169"
+ }
+
+ .fa-y-combinator:before {
+ 	content: "\F23B"
+ }
+
+ .fa-yahoo:before {
+ 	content: "\F19E"
+ }
+
+ .fa-yandex:before {
+ 	content: "\F413"
+ }
+
+ .fa-yandex-international:before {
+ 	content: "\F414"
+ }
+
+ .fa-yelp:before {
+ 	content: "\F1E9"
+ }
+
+ .fa-yen-sign:before {
+ 	content: "\F157"
+ }
+
+ .fa-yoast:before {
+ 	content: "\F2B1"
+ }
+
+ .fa-youtube:before {
+ 	content: "\F167"
+ }
+
+ .fa-youtube-square:before {
+ 	content: "\F431"
+ }
+
+ .sr-only {
+ 	border: 0;
+ 	clip: rect(0, 0, 0, 0);
+ 	height: 1px;
+ 	margin: -1px;
+ 	overflow: hidden;
+ 	padding: 0;
+ 	position: absolute;
+ 	width: 1px
+ }
+
+ .sr-only-focusable:active,
+ .sr-only-focusable:focus {
+ 	clip: auto;
+ 	height: auto;
+ 	margin: 0;
+ 	overflow: visible;
+ 	position: static;
+ 	width: auto
+ }
+
+ @font-face {
+ 	font-family: Font Awesome\ 5 Brands;
+ 	font-style: normal;
+ 	font-weight: 400;
+ 	src: url(fa-brands-400.eot);
+ 	src: url(fa-brands-400.eot?#iefix) format("embedded-opentype"), url(fa-brands-400.woff2) format("woff2"), url(fa-brands-400.woff) format("woff"), url(fa-brands-400.ttf) format("truetype"), url(fa-brands-400.svg#fontawesome) format("svg")
+ }
+
+ .fab {
+ 	font-family: Font Awesome\ 5 Brands
+ }
+
+ @font-face {
+ 	font-family: Font Awesome\ 5 Free;
+ 	font-style: normal;
+ 	font-weight: 400;
+ 	src: url(fa-regular-400.eot);
+ 	src: url(fa-regular-400.eot?#iefix) format("embedded-opentype"), url(fa-regular-400.woff2) format("woff2"), url(fa-regular-400.woff) format("woff"), url(fa-regular-400.ttf) format("truetype"), url(fa-regular-400.svg#fontawesome) format("svg")
+ }
+
+ .far {
+ 	font-weight: 400
+ }
+
+ @font-face {
+ 	font-family: Font Awesome\ 5 Free;
+ 	font-style: normal;
+ 	font-weight: 900;
+ 	src: url(fa-solid-900.eot);
+ 	src: url(fa-solid-900.eot?#iefix) format("embedded-opentype"), url(fa-solid-900.woff2) format("woff2"), url(fa-solid-900.woff) format("woff"), url(fa-solid-900.ttf) format("truetype"), url(fa-solid-900.svg#fontawesome) format("svg")
+ }
+
+ .fa,
+ .far,
+ .fas {
+ 	font-family: inherit;
+ }
+
+ .fa,
+ .fas {
+ 	font-weight: 900
+ }
 
 .shariff:after,
 .shariff:before {
@@ -3654,7 +3654,7 @@
 }
 
 .shariff .theme-grey .shariff-button a {
-	background-color: #b0b0b0
+	background-color: #b0b0b0;
 }
 
 .shariff .theme-grey .shariff-button .share_count {
@@ -3796,7 +3796,8 @@
 }
 
 .shariff .addthis .fa-plus {
-	font-size: 14px
+	font-size: 14px;
+  font-family: Font Awesome\ 5 Free;
 }
 
 .shariff .addthis .share_count {
@@ -3824,8 +3825,9 @@
 	background-color: #b3b3b3
 }
 
-.shariff .diaspora .fa-times-circle {
-	font-size: 17px
+.shariff .diaspora .fa-asterisk {
+	font-size: 17px;
+  font-family: Font Awesome\ 5 Free;
 }
 
 .shariff .theme-white .diaspora a {
@@ -3833,8 +3835,9 @@
 }
 
 @media only screen and (min-width:600px) {
-	.shariff .diaspora .fa-times-circle {
-		font-size: 16px
+	.shariff .diaspora .fa-asterisk {
+		font-size: 16px;
+    font-family: Font Awesome\ 5 Free;
 	}
 }
 
@@ -3879,7 +3882,8 @@
 }
 
 .shariff .flattr .fa-money-bill-alt {
-	font-size: 22px
+	font-size: 22px;
+  font-family: Font Awesome\ 5 Free;
 }
 
 .shariff .flattr .share_count {
@@ -3961,6 +3965,7 @@
 
 .shariff .info .fa-info {
 	font-size: 20px;
+  font-family: Font Awesome\ 5 Free;
 	width: 33px
 }
 
@@ -4042,7 +4047,8 @@
 }
 
 .shariff .mail .fa-envelope {
-	font-size: 21px
+	font-size: 21px;
+  font-family: Font Awesome\ 5 Free;
 }
 
 .shariff .theme-white .mail a {
@@ -4064,6 +4070,7 @@
 }
 
 .shariff .print .fa-print {
+  font-family: Font Awesome\ 5 Free;
 	font-size: 21px
 }
 
@@ -4086,7 +4093,7 @@
 }
 
 .shariff .pinterest .fa-pinterest-p {
-	font-size: 22px
+	font-size: 22px;
 }
 
 .shariff .pinterest .share_count {
@@ -4257,7 +4264,8 @@
 }
 
 .shariff .threema .fa-lock {
-	font-size: 28px
+  font-size: 28px;
+  font-family: Font Awesome\ 5 Free;
 }
 
 .shariff .theme-white .threema a {


### PR DESCRIPTION
This PR has to be tested! I am not a CSS expert.

But it works for me. I tested it on MW 1.31.7 with vector and chameleon  2.2.0  skin.

It leaves the font-awesome icons that you can use with chameleon-skin (in menus) alone, but still shows correct icons in the buttons. So for me it solves https://github.com/vonloxley/Shariff-Mediawiki/issues/4

Also I checked that it still works with vector skin. You can see it here:
https://testwiki2.kdz.eu//index.php?title=ShariffTest
https://testwiki2.kdz.eu//index.php?title=ShariffTest&useskin=vector