### PR TITLE
acknowledge wiki language for Shariff

### DIFF
--- a/Shariff.php
+++ b/Shariff.php
@@ -36,7 +36,7 @@ class Shariff {
 		global $wgScriptPath;
 		global $wgLanguageCode;
 
-		if ($wgLanguageCode == "de-formal" or $wgLanguageCode == "de-AT" or $wgLanguageCode == "de-CH" ) {
+		if (substr($wgLanguageCode, 0, 3) === 'de-') {
 			$datalang = "de";
 			}
 		else {

--- a/Shariff.php
+++ b/Shariff.php
@@ -7,7 +7,7 @@
  * @package MediaWiki
  * @subpackage Extensions
  * @author Niki Hansche
- * @copyright © 2014-2018 Niki Hansche
+ * @copyright Â© 2014-2018 Niki Hansche
  * @licence The MIT License (MIT)
  */
 
@@ -34,9 +34,17 @@ class Shariff {
 	static function shariffLikeParserFunction_Render( &$parser, $param1 = '', $param2 = '', $param3 = '' ) {
 		global $wgSitename;
 		global $wgScriptPath;
+		global $wgLanguageCode;
 
+		if ($wgLanguageCode == "de-formal" or $wgLanguageCode == "de-AT" or $wgLanguageCode == "de-CH" ) {
+			$datalang = "de";
+			}
+		else {
+			$datalang = $wgLanguageCode;
+		}
+		
 		//Get page title and URL
-		$output = '<div class="shariff noprint" data-backend-url="'.$wgScriptPath.'/extensions/Shariff/shariff-backend/" data-services="[&quot;twitter&quot;,&quot;facebook&quot;,&quot;pinterest&quot;]"></div>';
+		$output = '<div class="shariff noprint" data-lang="'.$datalang.'" data-backend-url="'.$wgScriptPath.'/extensions/Shariff/shariff-backend/" data-services="[&quot;twitter&quot;,&quot;facebook&quot;,&quot;pinterest&quot;]"></div>';
 
 		return $parser->insertStripItem($output, $parser->mStripState);;
 	}


### PR DESCRIPTION
not perfect, but acknowledges at least different de language versions (de-formal, de-AT, de-CH) in mediawiki to be mapped to "de" in Shariff.

Solves the problem better than https://github.com/vonloxley/Shariff-Mediawiki/pull/7

in reference to https://github.com/vonloxley/Shariff-Mediawiki/issues/6