### PR TITLE
Replace use of Parser::$mStripState, deprecated in 1.35

### DIFF
--- a/Shariff.php
+++ b/Shariff.php
@@ -42,6 +42,6 @@ class Shariff {
 		//Get page title and URL
 		$output = '<div class="shariff noprint" data-lang="'.$datalang.'" data-backend-url="'.$wgScriptPath.'/extensions/Shariff/shariff-backend/" data-services="[&quot;twitter&quot;,&quot;facebook&quot;,&quot;pinterest&quot;]"></div>';
 
-		return $parser->insertStripItem($output, $parser->mStripState);;
+		return $parser->insertStripItem($output, $parser->getStripState());
 	}
 }

--- a/extension.json
+++ b/extension.json
@@ -7,7 +7,7 @@
 	"license-name": "MIT",
 	"type": "other",
 	"requires": {
-		"MediaWiki": ">= 1.29.0"
+		"MediaWiki": ">= 1.34.0"
 	},
 	"AutoloadClasses": {
 		"Shariff": "Shariff.php"


### PR DESCRIPTION
The replacement, Parser::getStripState(), was added to MediaWiki in
1.34.  Accordingly, the minimum required MediaWiki version for this
extension has been bumped to 1.34.

Bug: T275160